### PR TITLE
Merge upstream Battle of the Kings updates and enable CI on work

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - master
       - tools
+      - work
   pull_request:
     branches:
       - master
       - tools
+      - work
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,9 +2,9 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, work ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, work ]
 
 env:
   EM_VERSION: 1.39.16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master, tools ]
+    branches: [ master, tools, work ]
   pull_request:
-    branches: [ master, tools ]
+    branches: [ master, tools, work ]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -5,10 +5,12 @@ on:
       - master
       - tools
       - github_ci
+      - work
   pull_request:
     branches:
       - master
       - tools
+      - work
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,9 +4,11 @@ on:
     push:
       branches:
         - master
+        - work
     pull_request:
       branches:
         - master
+        - work
 
 jobs:
   build_wheels:

--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -105,7 +105,9 @@ namespace Stockfish::Eval::NNUE::Features {
     return pos.count<ALL_PIECES>();
   }
 
-  bool HalfKAv2Variants::requires_refresh(StateInfo* st, Color perspective, const Position& pos) {
+  bool HalfKAv2Variants::requires_refresh([[maybe_unused]] StateInfo* st,
+                                          [[maybe_unused]] Color perspective,
+                                          [[maybe_unused]] const Position& pos) {
     return true;
   }
 

--- a/test.py
+++ b/test.py
@@ -411,6 +411,28 @@ class TestPyffish(unittest.TestCase):
                 file_index += 1
         self.assertEqual(d_file_piece, "N")
 
+    def test_battlekings_en_passant_keeps_gate_available(self):
+        start = sf.start_fen("battlekings")
+        setup = ["e2e3", "c7c5", "f2f3", "c5c4", "d2d4"]
+        expected = "8/ppnppppp/8/2n5/2n5/3pPP2/PPPNNNPP/8 w - - 0 4"
+
+        fen = sf.get_fen("battlekings", start, setup + ["c4d3"])
+        self.assertEqual(fen, expected)
+
+    def test_battlekings_forced_promotion_and_gate(self):
+        start = "8/ppnppppp/8/2n5/2N1P3/2P1BP2/PNPpNNPP/8 b - - 0 5"
+        expected = "8/ppnppppp/8/2n5/2N1P3/2P1BP2/PNPnNNPP/3n4 w - - 0 6"
+
+        legal = sf.legal_moves("battlekings", start, [])
+        self.assertIn("d2d1", legal)
+
+        fen = sf.get_fen("battlekings", start, ["d2d1"])
+        self.assertEqual(fen, expected)
+
+    def test_chess_promotion_does_not_gate(self):
+        start = "8/P7/8/8/8/8/7p/7K w - - 0 1"
+        fen = sf.get_fen("chess", start, ["a7a8q"])
+        self.assertEqual(fen, "Q7/8/8/8/8/8/7p/7K b - - 0 1")
     def test_battlekings_king_spawn_blocked(self):
         fen = "8/8/8/8/8/3p4/4Q3/8 w - - 0 1"
         moves = sf.legal_moves("battlekings", fen, [])


### PR DESCRIPTION
## Summary
- merge upstream codex/implement-battle-of-the-kings-variant-7bhqbn to bring in Battle Kings move ordering heuristics and regression tests
- silence unused parameter warnings in the NNUE variant feature helper
- allow all GitHub workflows to run on pushes and pull requests for the work branch so CI triggers on this PR

## Testing
- python3 -m compileall test.py

------
https://chatgpt.com/codex/tasks/task_e_68dd96d4342483228f36157ad9ee6c62