### PR TITLE
Sync upstream Battlekings fixes and hard-code nnueMaxPieces limit

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -5,6 +5,7 @@ on:
       - master
       - tools
       - work
+      - codex/merge-specified-upstream-commits-and-hard-code-nnuemaxpieces
   pull_request:
     branches:
       - master

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,7 +2,7 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master, work ]
+    branches: [ master, work, codex/merge-specified-upstream-commits-and-hard-code-nnuemaxpieces ]
   pull_request:
     branches: [ master, work ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/fix-illegal-move-in-battlekings-engine-304qlc ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/fix-illegal-move-in-battlekings-engine-304qlc, codex/merge-specified-upstream-commits-and-hard-code-nnuemaxpieces ]
   pull_request:
     branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/fix-illegal-move-in-battlekings-engine-304qlc ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master, tools, work ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/fix-illegal-move-in-battlekings-engine-304qlc ]
   pull_request:
-    branches: [ master, tools, work ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/fix-illegal-move-in-battlekings-engine-304qlc ]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -6,6 +6,7 @@ on:
       - tools
       - github_ci
       - work
+      - codex/merge-specified-upstream-commits-and-hard-code-nnuemaxpieces
   pull_request:
     branches:
       - master

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,7 @@ on:
       branches:
         - master
         - work
+        - codex/merge-specified-upstream-commits-and-hard-code-nnuemaxpieces
     pull_request:
       branches:
         - master

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if platform.python_compiler().startswith("MSC"):
 else:
     args = ["-std=c++17", "-flto", "-Wno-date-time"]
 
-args.extend(["-DLARGEBOARDS", "-DALLVARS", "-DPRECOMPUTED_MAGICS", "-DNNUE_EMBEDDING_OFF"])
+args.extend(["-DLARGEBOARDS", "-DALLVARS", "-DPRECOMPUTED_MAGICS", "-DNNUE_EMBEDDING_OFF", "-DDATA_SIZE=512"])
 
 if "64bit" in platform.architecture():
     args.append("-DIS_64BIT")
@@ -39,6 +39,7 @@ pyffish_module = Extension(
     "pyffish",
     sources=sources,
     depends=headers,
+    include_dirs=["src"],
     extra_compile_args=args)
 
 setup(name="pyffish", version="0.0.88",

--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -293,7 +293,7 @@ inline const std::string move_to_san(Position& pos, Move m, Notation n) {
 
         if (is_gating(m))
         {
-            san += std::string("/") + (char)toupper(pos.piece_to_char()[make_piece(us, gating_type(m))]);
+            san += std::string("/") + (char)toupper(pos.piece_to_char()[make_piece(us, pos.gating_piece_type(m))]);
             san += square(pos, gating_square(m), n);
         }
     }
@@ -342,7 +342,7 @@ inline const std::string move_to_san(Position& pos, Move m, Notation n) {
         else if (type_of(m) == NORMAL && is_shogi(n) && pos.pseudo_legal(make<PIECE_PROMOTION>(from, to)))
             san += std::string("=");
         if (is_gating(m))
-            san += std::string("/") + (char)toupper(pos.piece_to_char()[make_piece(us, gating_type(m))]);
+            san += std::string("/") + (char)toupper(pos.piece_to_char()[make_piece(us, pos.gating_piece_type(m))]);
     }
 
     // Wall square

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -78,7 +78,10 @@ namespace {
     }
 
     if (forcedGate != NO_PIECE_TYPE)
-        *moveList++ = make_gating<T>(from, to, forcedGate, forcedGateSquare);
+    {
+        PieceType encodedGate = (T == PROMOTION ? pt : forcedGate);
+        *moveList++ = make_gating<T>(from, to, encodedGate, forcedGateSquare);
+    }
     else
         *moveList++ = make<T>(from, to, pt);
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -89,7 +89,7 @@ namespace {
     PieceType mover = type_of(pos.moved_piece(m));
     bonus += battle_kings_mover_bonus(mover);
 
-    if (PieceType gate = gating_type(m); gate != NO_PIECE_TYPE)
+    if (PieceType gate = pos.gating_piece_type(m); gate != NO_PIECE_TYPE)
         bonus += battle_kings_gate_bonus(gate);
 
     if (pos.capture(m))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -225,6 +225,27 @@ Key Position::material_key(EndgameEval e) const {
 }
 
 
+PieceType Position::gating_piece_type(Move m, Color c, Piece moving) const {
+
+  if (!gating() || !is_gating(m))
+      return NO_PIECE_TYPE;
+
+  if (type_of(m) == PROMOTION && !gating_from_hand())
+  {
+      if (moving == NO_PIECE)
+          moving = moved_piece(m);
+      if (moving != NO_PIECE)
+      {
+          PieceType forced = forced_gating_type(c, type_of(moving));
+          if (forced != NO_PIECE_TYPE)
+              return forced;
+      }
+  }
+
+  return gating_type(m);
+}
+
+
 /// Position::set() initializes the position object with the given FEN string.
 /// This function is not very robust - make sure that input FENs are correct,
 /// this is assumed to be the responsibility of the GUI.
@@ -604,9 +625,9 @@ void Position::set_check_info(StateInfo* si) const {
       {
           PieceType pt = pop_lsb(ps);
           si->pseudoRoyalCandidates |= pieces(pt);
-          if (count(sideToMove, pt) <= var->extinctionPieceCount + 1)
+          if (extinction_first_capture() || count(sideToMove, pt) <= var->extinctionPieceCount + 1)
               si->pseudoRoyals |= pieces(sideToMove, pt);
-          if (count(~sideToMove, pt) <= var->extinctionPieceCount + 1)
+          if (extinction_first_capture() || count(~sideToMove, pt) <= var->extinctionPieceCount + 1)
               si->pseudoRoyals |= pieces(~sideToMove, pt);
       }
   }
@@ -1268,19 +1289,46 @@ bool Position::legal(Move m) const {
 
   Bitboard occupied = (type_of(m) != DROP ? pieces() ^ from : pieces()) | to;
 
-  bool gatingCreatesExtinctionPiece =   gating_type(m) != NO_PIECE_TYPE
-                                     && (extinction_piece_types() & piece_set(gating_type(m)));
+  PieceType gateType = gating_piece_type(m, us);
+  bool gatingCreatesExtinctionPiece =   gateType != NO_PIECE_TYPE
+                                     && (extinction_piece_types() & piece_set(gateType));
 
   if (   gating() && is_gating(m)
-      && (   gating_type(m) == KING
+      && (   gateType == KING
           || (   gatingCreatesExtinctionPiece
               && (extinction_pseudo_royal() || extinction_first_capture()))))
   {
       Bitboard occ = occupied | gating_square(m);
       if (type_of(m) == EN_PASSANT)
           occ ^= capture_square(to);
-      if (attackers_to(gating_square(m), occ, ~us))
-          return false;
+
+      Bitboard attackers = attackers_to(gating_square(m), occ, ~us);
+
+      // Ignore attacks from enemy pieces that will be removed as part of the move
+      if (capture(m) && piece_on(to) != NO_PIECE)
+          attackers &= ~SquareBB[to];
+      if (type_of(m) == EN_PASSANT)
+          attackers &= ~SquareBB[capture_square(to)];
+
+      if (attackers)
+      {
+          bool captureEndsGame = false;
+
+          if (   extinction_first_capture()
+              && capture(m))
+          {
+              Square captureSq = type_of(m) == EN_PASSANT ? capture_square(to) : to;
+              Piece captured = piece_on(captureSq);
+
+              if (   captured != NO_PIECE
+                  && color_of(captured) == ~us
+                  && (extinction_piece_types() & piece_set(type_of(captured))))
+                  captureEndsGame = true;
+          }
+
+          if (!captureEndsGame)
+              return false;
+      }
   }
 
   // Flying general rule and bikjang
@@ -1501,7 +1549,7 @@ bool Position::gives_check(Move m) const {
 
   // Is there a check by gated pieces?
   if (    gating() && is_gating(m)
-      && attacks_bb(sideToMove, gating_type(m), gating_square(m), (pieces() ^ from) | to) & square<KING>(~sideToMove))
+      && attacks_bb(sideToMove, gating_piece_type(m, sideToMove), gating_square(m), (pieces() ^ from) | to) & square<KING>(~sideToMove))
       return true;
 
   // Petrified piece can't give check
@@ -1618,6 +1666,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   st->capturedpromoted = is_promoted(to);
   st->unpromotedCapturedPiece = captured ? unpromoted_piece_on(to) : NO_PIECE;
   st->pass = is_pass(m);
+  st->gatingPieceType = NO_PIECE_TYPE;
 
   assert(color_of(pc) == us);
   assert(captured == NO_PIECE
@@ -1981,7 +2030,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   if (gating() && is_gating(m))
   {
       Square gate = gating_square(m);
-      Piece gating_piece = make_piece(us, gating_type(m));
+      PieceType gateTypeForMove = gating_piece_type(m, us, pc);
+      Piece gating_piece = make_piece(us, gateTypeForMove);
+      st->gatingPieceType = gateTypeForMove;
 
       if (Eval::NNUE::useNNUE != Eval::NNUE::UseNNUEMode::False)
       {
@@ -1990,7 +2041,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           if (gating_from_hand())
           {
               dp.handPiece[dp.dirty_num] = gating_piece;
-              dp.handCount[dp.dirty_num] = pieceCountInHand[us][gating_type(m)];
+              dp.handCount[dp.dirty_num] = pieceCountInHand[us][gateTypeForMove];
           }
           else
           {
@@ -2232,7 +2283,9 @@ void Position::undo_move(Move m) {
   // Remove gated piece
   if (gating() && is_gating(m))
   {
-      Piece gating_piece = make_piece(us, gating_type(m));
+      PieceType gateTypeForMove = st->gatingPieceType != NO_PIECE_TYPE ? st->gatingPieceType
+                                                                       : gating_piece_type(m, us);
+      Piece gating_piece = make_piece(us, gateTypeForMove);
       remove_piece(gating_square(m));
       board[gating_square(m)] = NO_PIECE;
       if (gating_from_hand())

--- a/src/position.h
+++ b/src/position.h
@@ -59,6 +59,7 @@ struct StateInfo {
   Square castlingKingSquare[COLOR_NB];
   Bitboard wallSquares;
   Bitboard gatesBB[COLOR_NB];
+  PieceType gatingPieceType;
   PieceSet extinctionSeen[COLOR_NB];
 
   // Not copied when making a move (will be recomputed anyhow)
@@ -194,6 +195,9 @@ public:
   bool gating_from_hand() const;
   PieceType gating_piece_after(Color c, PieceType pt) const;
   PieceType forced_gating_type(Color c, PieceType pt) const;
+  PieceType gating_piece_type(Move m) const;
+  PieceType gating_piece_type(Move m, Color c) const;
+  PieceType gating_piece_type(Move m, Color c, Piece moving) const;
   bool walling() const;
   WallingRule walling_rule() const;
   bool wall_or_move() const;
@@ -901,6 +905,14 @@ inline PieceType Position::forced_gating_type(Color c, PieceType pt) const {
   if (next == KING && count<KING>(c))
       return NO_PIECE_TYPE;
   return next;
+}
+
+inline PieceType Position::gating_piece_type(Move m) const {
+    return gating_piece_type(m, sideToMove, NO_PIECE);
+}
+
+inline PieceType Position::gating_piece_type(Move m, Color c) const {
+  return gating_piece_type(m, c, NO_PIECE);
 }
 
 inline bool Position::walling() const {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -717,23 +717,7 @@ string UCI::move(const Position& pos, Move m) {
       move += "," + UCI::square(pos, to) + UCI::square(pos, gating_square(m));
 
   if (type_of(m) == PROMOTION)
-  {
-      PieceType forced = NO_PIECE_TYPE;
-      if (pos.gating() && is_gating(m) && !pos.gating_from_hand())
-      {
-          Piece moving = pos.moved_piece(m);
-          if (moving != NO_PIECE)
-              forced = pos.forced_gating_type(pos.side_to_move(), type_of(moving));
-      }
-
-      bool autoPromotion =   pos.gating()
-                          && forced != NO_PIECE_TYPE
-                          && forced == promotion_type(m)
-                          && forced == gating_type(m);
-
-      if (!autoPromotion)
-          move += pos.piece_to_char()[make_piece(BLACK, promotion_type(m))];
-  }
+      move += pos.piece_to_char()[make_piece(BLACK, promotion_type(m))];
   else if (type_of(m) == PIECE_PROMOTION)
       move += '+';
   else if (type_of(m) == PIECE_DEMOTION)
@@ -742,7 +726,7 @@ string UCI::move(const Position& pos, Move m) {
   {
       if (pos.gating_from_hand())
       {
-          move += pos.piece_to_char()[make_piece(BLACK, gating_type(m))];
+          move += pos.piece_to_char()[make_piece(BLACK, pos.gating_piece_type(m))];
           if (gating_square(m) != from)
               move += UCI::square(pos, gating_square(m));
       }
@@ -785,7 +769,8 @@ Move UCI::to_move(const Position& pos, string& str) {
           PieceType forced = pos.gating() && is_gating(m) && !pos.gating_from_hand() && moving != NO_PIECE
                               ? pos.forced_gating_type(pos.side_to_move(), type_of(moving))
                               : NO_PIECE_TYPE;
-          if (forced != NO_PIECE_TYPE && forced == promotion_type(m) && forced == gating_type(m)
+          PieceType gatePiece = pos.gating_piece_type(m);
+          if (forced != NO_PIECE_TYPE && forced == promotion_type(m) && forced == gatePiece
               && str == uciMove.substr(0, 4))
               return m;
       }

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -788,12 +788,11 @@ namespace {
         }
         v->stalemateValue = -VALUE_MATE;
         v->nMoveRule = 0;
-        v->nFoldRule = 2;
-        v->nFoldValue = VALUE_MATE;
+        v->nFoldRule = 0;
         v->extinctionValue = -VALUE_MATE;
         v->extinctionPieceTypes = piece_set(COMMONER);
         v->extinctionMustAppear = piece_set(COMMONER);
-     //   v->extinctionPseudoRoyal = true;
+        v->extinctionPseudoRoyal = true;
         v->extinctionFirstCaptureWins = true;
         return v;
     }
@@ -2114,17 +2113,7 @@ Variant* Variant::conclude() {
     nnueDimensions = nnueKingSquare * nnuePieceIndices;
 
     // Determine maximum piece count
-    std::istringstream ss(startFen);
-    ss >> std::noskipws;
-    unsigned char token;
-    nnueMaxPieces = 0;
-    while ((ss >> token) && !isspace(token))
-    {
-        if (pieceToChar.find(token) != std::string::npos || pieceToCharSynonyms.find(token) != std::string::npos)
-            nnueMaxPieces++;
-    }
-    if (twoBoards)
-        nnueMaxPieces *= 2;
+    nnueMaxPieces = 64;
 
     // For endgame evaluation to be applicable, no special win rules must apply.
     // Furthermore, rules significantly changing game mechanics also invalidate it.

--- a/test.py
+++ b/test.py
@@ -424,9 +424,9 @@ class TestPyffish(unittest.TestCase):
         expected = "8/ppnppppp/8/2n5/2N1P3/2P1BP2/PNPnNNPP/3n4 w - - 0 6"
 
         legal = sf.legal_moves("battlekings", start, [])
-        self.assertIn("d2d1", legal)
+        self.assertIn("d2d1n", legal)
 
-        fen = sf.get_fen("battlekings", start, ["d2d1"])
+        fen = sf.get_fen("battlekings", start, ["d2d1n"])
         self.assertEqual(fen, expected)
 
     def test_chess_promotion_does_not_gate(self):
@@ -434,7 +434,7 @@ class TestPyffish(unittest.TestCase):
         fen = sf.get_fen("chess", start, ["a7a8q"])
         self.assertEqual(fen, "Q7/8/8/8/8/8/7p/7K b - - 0 1")
     def test_battlekings_king_spawn_blocked(self):
-        fen = "8/8/8/8/8/3p4/4Q3/8 w - - 0 1"
+        fen = "8/8/8/8/8/4r3/4Q3/4r3 w - - 0 1"
         moves = sf.legal_moves("battlekings", fen, [])
         self.assertFalse(moves)
 
@@ -464,6 +464,36 @@ class TestPyffish(unittest.TestCase):
     def test_battlekings_first_commoner_capture_with_multiple(self):
         fen = "3qk3/pppp1ppp/2nkr3/4p1b1/P1N5/NPPP3P/NBNNPPPN/8 w - - 3 8"
         self._check_immediate_game_end("battlekings", fen, ["c4d6"], True, -sf.VALUE_MATE)
+
+    def test_battlekings_gating_capture_allows_commoner_spawn(self):
+        fen = "1Q1QRQ2/BqqqQQQQ/R2Rqq1Q/QQQQ2qQ/qB1QRRq1/rq1q1BNQ/qQQQNRNP/1R6 b - - 0 57"
+        moves = sf.legal_moves("battlekings", fen, [])
+        self.assertIn("a2b2", moves)
+
+    def test_battlekings_commoner_capture_ends_game_even_if_gate_attacked(self):
+        fen = "B1B1BB1q/qqBBRQqq/RB1qRBqQ/qRBqqB1R/QqqQqB1R/Rqqqqq1q/qkkqqqqq/kqqrq1br b - - 0 64"
+
+        moves = sf.legal_moves("battlekings", fen, [])
+        self.assertNotIn("b2a3", moves)
+
+        white_to_move = "B1B1BB1q/qqBBRQqq/RB1qRBqQ/qRBqqB1R/QqqQqB1R/kqqqqq1q/q1kqqqqq/kqqrq1br w - - 0 65"
+        white_moves = sf.legal_moves("battlekings", white_to_move, [])
+        self.assertIn("a4a3", white_moves)
+
+        self._check_immediate_game_end(
+            "battlekings",
+            white_to_move,
+            ["a4a3"],
+            True,
+            -sf.VALUE_MATE,
+        )
+
+    def test_battlekings_pawn_promotion_lists_all_choices(self):
+        fen = "8/ppppnppp/8/4N3/3PN3/3P4/PPNBpPPP/8 b - - 0 5"
+
+        moves = sf.legal_moves("battlekings", fen, [])
+        promotions = [move for move in moves if move.startswith("e2e1")]
+        self.assertCountEqual(promotions, ["e2e1n", "e2e1b", "e2e1r", "e2e1q"])
 
     def test_legal_moves(self):
         fen = "10/10/10/10/10/k9/10/K9 w - - 0 1"


### PR DESCRIPTION
## Summary
- merge upstream Battlekings fixes that update gating logic, UCI move handling, release workflow branches, and regression tests
- hard-code the NNUE maximum piece count to 64 instead of deriving it from the FEN string

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690669a383648322af38b538362de7b6