### PR TITLE
Remove comments from requirements.txt while preserving Windows CUDA 11.8 pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cu118
+
+torch==2.7.1+cu118; platform_system == "Windows"
+torchvision==0.22.1+cu118; platform_system == "Windows"
+torchaudio==2.7.1+cu118; platform_system == "Windows"


### PR DESCRIPTION
### Motivation
- Make `requirements.txt` minimal by removing inline comments while retaining the intended platform-specific PyTorch wheel selection.
- Ensure Windows `pip` installs continue to prefer PyTorch CUDA 11.8 wheels via `--extra-index-url`.
- Keep explicit Windows-only package pins so non-Windows platforms are unaffected.

### Description
- Add/update `requirements.txt` at the repository root containing `--extra-index-url https://download.pytorch.org/whl/cu118`.
- Pin `torch==2.7.1+cu118`, `torchvision==0.22.1+cu118`, and `torchaudio==2.7.1+cu118` with `platform_system == "Windows"` markers.
- Remove all comment lines so the file contains only the index URL and the Windows-specific package pins.
- Commit made with the message `Remove comments from requirements`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fb09c990832290f5919e53e62a0f)