### PR TITLE
Tools: encode wall squares in PackedSfen and NNUE features

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -119,7 +119,7 @@ namespace Stockfish::Eval::NNUE {
 
     std::uint32_t hashValue;
     if (!read_header(stream, &hashValue, &netDescription)) return false;
-    if (hashValue != HashValue) return false;
+    if (hashValue != hash_value()) return false;
     if (!Detail::read_parameters(stream, *featureTransformer)) return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
       if (!Detail::read_parameters(stream, *(network[i]))) return false;
@@ -129,7 +129,7 @@ namespace Stockfish::Eval::NNUE {
   // Write network parameters
   bool write_parameters(std::ostream& stream) {
 
-    if (!write_header(stream, HashValue, netDescription)) return false;
+    if (!write_header(stream, hash_value(), netDescription)) return false;
     if (!Detail::write_parameters(stream, *featureTransformer)) return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
       if (!Detail::write_parameters(stream, *(network[i]))) return false;

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -28,8 +28,9 @@
 namespace Stockfish::Eval::NNUE {
 
   // Hash value of evaluation function structure
-  constexpr std::uint32_t HashValue =
-      FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
+  inline std::uint32_t hash_value() {
+    return FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
+  }
 
   // Deleter for automating release of memory area
   template <typename T>

--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -64,11 +64,14 @@ namespace Stockfish::Eval::NNUE::Features {
       active.push_back(make_index(perspective, s, pos.piece_on(s), oriented_ksq, pos));
     }
 
-    Bitboard walls = pos.state()->wallSquares;
-    while (walls)
+    if (pos.nnue_wall_index_base() >= 0)
     {
-      Square s = pop_lsb(walls);
-      active.push_back(make_wall_index(perspective, s, oriented_ksq, pos));
+      Bitboard walls = pos.state()->wallSquares;
+      while (walls)
+      {
+        Square s = pop_lsb(walls);
+        active.push_back(make_wall_index(perspective, s, oriented_ksq, pos));
+      }
     }
 
     // Indices for pieces in hand
@@ -107,22 +110,30 @@ namespace Stockfish::Eval::NNUE::Features {
         added.push_back(make_index(perspective, dp.handCount[i] - 1, dp.handPiece[i], oriented_ksq, pos));
     }
 
-    Bitboard prevWalls = st->previous ? st->previous->wallSquares : Bitboard(0);
-    Bitboard removedWalls = prevWalls & ~st->wallSquares;
-    Bitboard addedWalls = st->wallSquares & ~prevWalls;
-    while (removedWalls)
-      removed.push_back(make_wall_index(perspective, pop_lsb(removedWalls), oriented_ksq, pos));
-    while (addedWalls)
-      added.push_back(make_wall_index(perspective, pop_lsb(addedWalls), oriented_ksq, pos));
+    if (pos.nnue_wall_index_base() >= 0)
+    {
+      Bitboard prevWalls = st->previous ? st->previous->wallSquares : Bitboard(0);
+      Bitboard removedWalls = prevWalls & ~st->wallSquares;
+      Bitboard addedWalls = st->wallSquares & ~prevWalls;
+      while (removedWalls)
+        removed.push_back(make_wall_index(perspective, pop_lsb(removedWalls), oriented_ksq, pos));
+      while (addedWalls)
+        added.push_back(make_wall_index(perspective, pop_lsb(addedWalls), oriented_ksq, pos));
+    }
   }
 
   int HalfKAv2Variants::update_cost(StateInfo* st) {
+    if (!currentNnueVariant || currentNnueVariant->nnueWallIndexBase < 0)
+      return st->dirtyPiece.dirty_num;
     Bitboard diff = st->previous ? st->wallSquares ^ st->previous->wallSquares : Bitboard(0);
     return st->dirtyPiece.dirty_num + popcount(diff);
   }
 
   int HalfKAv2Variants::refresh_cost(const Position& pos) {
-    return pos.count<ALL_PIECES>() + popcount(pos.state()->wallSquares);
+    int cost = pos.count<ALL_PIECES>();
+    if (pos.nnue_wall_index_base() >= 0)
+      cost += popcount(pos.state()->wallSquares);
+    return cost;
   }
 
   bool HalfKAv2Variants::requires_refresh(StateInfo* st, Color perspective, const Position& pos) {

--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -46,6 +46,10 @@ namespace Stockfish::Eval::NNUE::Features {
     return IndexType(handCount + pos.nnue_piece_hand_index(perspective, pc) + pos.nnue_king_square_index(ksq));
   }
 
+  inline IndexType HalfKAv2Variants::make_wall_index(Color perspective, Square s, Square ksq, const Position& pos) {
+    return IndexType(orient(perspective, s, pos) + pos.nnue_wall_index_base() + pos.nnue_king_square_index(ksq));
+  }
+
   // Get a list of indices for active features
   void HalfKAv2Variants::append_active_indices(
     const Position& pos,
@@ -58,6 +62,13 @@ namespace Stockfish::Eval::NNUE::Features {
     {
       Square s = pop_lsb(bb);
       active.push_back(make_index(perspective, s, pos.piece_on(s), oriented_ksq, pos));
+    }
+
+    Bitboard walls = pos.state()->wallSquares;
+    while (walls)
+    {
+      Square s = pop_lsb(walls);
+      active.push_back(make_wall_index(perspective, s, oriented_ksq, pos));
     }
 
     // Indices for pieces in hand
@@ -95,14 +106,23 @@ namespace Stockfish::Eval::NNUE::Features {
       else if (dp.handPiece[i] != NO_PIECE)
         added.push_back(make_index(perspective, dp.handCount[i] - 1, dp.handPiece[i], oriented_ksq, pos));
     }
+
+    Bitboard prevWalls = st->previous ? st->previous->wallSquares : Bitboard(0);
+    Bitboard removedWalls = prevWalls & ~st->wallSquares;
+    Bitboard addedWalls = st->wallSquares & ~prevWalls;
+    while (removedWalls)
+      removed.push_back(make_wall_index(perspective, pop_lsb(removedWalls), oriented_ksq, pos));
+    while (addedWalls)
+      added.push_back(make_wall_index(perspective, pop_lsb(addedWalls), oriented_ksq, pos));
   }
 
   int HalfKAv2Variants::update_cost(StateInfo* st) {
-    return st->dirtyPiece.dirty_num;
+    Bitboard diff = st->previous ? st->wallSquares ^ st->previous->wallSquares : Bitboard(0);
+    return st->dirtyPiece.dirty_num + popcount(diff);
   }
 
   int HalfKAv2Variants::refresh_cost(const Position& pos) {
-    return pos.count<ALL_PIECES>();
+    return pos.count<ALL_PIECES>() + popcount(pos.state()->wallSquares);
   }
 
   bool HalfKAv2Variants::requires_refresh(StateInfo* st, Color perspective, const Position& pos) {

--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -125,7 +125,7 @@ namespace Stockfish::Eval::NNUE::Features {
   int HalfKAv2Variants::update_cost(StateInfo* st) {
     if (!currentNnueVariant || currentNnueVariant->nnueWallIndexBase < 0)
       return st->dirtyPiece.dirty_num;
-    Bitboard diff = st->previous ? st->wallSquares ^ st->previous->wallSquares : Bitboard(0);
+    Bitboard diff = st->previous ? st->wallSquares ^ st->previous->wallSquares : st->wallSquares;
     return st->dirtyPiece.dirty_num + popcount(diff);
   }
 

--- a/src/nnue/features/half_ka_v2_variants.h
+++ b/src/nnue/features/half_ka_v2_variants.h
@@ -47,22 +47,25 @@ namespace Stockfish::Eval::NNUE::Features {
     // Index of a feature for a given king position and another piece in hand
     static IndexType make_index(Color perspective, int handCount, Piece pc, Square ksq, const Position& pos);
 
+    // Index of a feature for a given king position and a wall square
+    static IndexType make_wall_index(Color perspective, Square s, Square ksq, const Position& pos);
+
    public:
     // Feature name
     static constexpr const char* Name = "HalfKAv2(Friend)";
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t HashValue = 0x5f234cb8u;
+    static constexpr std::uint32_t HashValue = 0x9e5a2c13u;
 
     // Number of feature dimensions
-    static constexpr IndexType Dimensions = static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(SQUARE_NB) * 19;
+    static constexpr IndexType Dimensions = static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(SQUARE_NB) * 20;
 
     static IndexType get_dimensions() {
       return currentNnueVariant->nnueDimensions;
     }
 
     // Maximum number of simultaneously active features.
-    static constexpr IndexType MaxActiveDimensions = 128;
+    static constexpr IndexType MaxActiveDimensions = 2 * static_cast<IndexType>(SQUARE_NB);
 
     // Get a list of indices for active features
     static void append_active_indices(

--- a/src/nnue/features/half_ka_v2_variants.h
+++ b/src/nnue/features/half_ka_v2_variants.h
@@ -55,7 +55,14 @@ namespace Stockfish::Eval::NNUE::Features {
     static constexpr const char* Name = "HalfKAv2(Friend)";
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t HashValue = 0x9e5a2c13u;
+    static constexpr std::uint32_t HashValueNoWalls = 0x5f234cb8u;
+    static constexpr std::uint32_t HashValueWithWalls = 0x9e5a2c13u;
+
+    static std::uint32_t get_hash_value() {
+      return currentNnueVariant && currentNnueVariant->nnueWallIndexBase >= 0
+             ? HashValueWithWalls
+             : HashValueNoWalls;
+    }
 
     // Number of feature dimensions
     static constexpr IndexType Dimensions = static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(SQUARE_NB) * 20;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -193,8 +193,8 @@ namespace Stockfish::Eval::NNUE {
         OutputDimensions * sizeof(OutputType);
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t get_hash_value() {
-      return FeatureSet::HashValue ^ OutputDimensions;
+    static std::uint32_t get_hash_value() {
+      return FeatureSet::get_hash_value() ^ OutputDimensions;
     }
 
     // Read network parameters

--- a/src/position.h
+++ b/src/position.h
@@ -159,11 +159,12 @@ public:
   PieceType king_type() const;
   PieceType nnue_king() const;
   Square nnue_king_square(Color c) const;
-  bool nnue_use_pockets() const;
-  bool nnue_applicable() const;
-  int nnue_piece_square_index(Color perspective, Piece pc) const;
-  int nnue_piece_hand_index(Color perspective, Piece pc) const;
-  int nnue_king_square_index(Square ksq) const;
+    bool nnue_use_pockets() const;
+    bool nnue_applicable() const;
+    int nnue_piece_square_index(Color perspective, Piece pc) const;
+    int nnue_piece_hand_index(Color perspective, Piece pc) const;
+    int nnue_king_square_index(Square ksq) const;
+    int nnue_wall_index_base() const;
   bool free_drops() const;
   bool fast_attacks() const;
   bool fast_attacks2() const;
@@ -634,15 +635,20 @@ inline int Position::nnue_piece_hand_index(Color perspective, Piece pc) const {
   return var->pieceHandIndex[perspective][pc];
 }
 
-inline int Position::nnue_king_square_index(Square ksq) const {
-  assert(var != nullptr);
-  return var->kingSquareIndex[ksq];
-}
+  inline int Position::nnue_king_square_index(Square ksq) const {
+    assert(var != nullptr);
+    return var->kingSquareIndex[ksq];
+  }
 
-inline bool Position::checking_permitted() const {
-  assert(var != nullptr);
-  return var->checking;
-}
+  inline int Position::nnue_wall_index_base() const {
+    assert(var != nullptr);
+    return var->nnueWallIndexBase;
+  }
+
+  inline bool Position::checking_permitted() const {
+    assert(var != nullptr);
+    return var->checking;
+  }
 
 inline bool Position::free_drops() const {
   assert(var != nullptr);

--- a/src/tools/sfen_packer.cpp
+++ b/src/tools/sfen_packer.cpp
@@ -82,7 +82,8 @@ namespace Stockfish::Tools {
     // sfen can be packed to 256bit (32bytes) by Huffman coding.
     // This is proven by mini. The above is Huffman coding.
     //
-    // Internal format = 1-bit turn + 7-bit king position *2 + piece on board (Huffman coding) + hand piece (Huffman coding)
+    // Internal format = 1-bit turn + 7-bit king position *2 + piece on board (Huffman coding)
+    //                + wall squares (1 bit per square) + hand piece (Huffman coding)
     // Side to move (White = 0, Black = 1) (1bit)
     // White King Position (6 bits)
     // Black King Position (6 bits)
@@ -129,6 +130,7 @@ namespace Stockfish::Tools {
     // - 40 pieces           240 bits
     // - 20 pockets          100 bits
     // - 2 kings             14 bits
+    // - wall squares        80 bits
     // - castling rights     4 bits
     // - ep square           8 bits
     // - rule50              7 bits
@@ -194,6 +196,16 @@ namespace Stockfish::Tools {
                 if (pos.nnue_king() && type_of(pc) == pos.nnue_king())
                     continue;
                 write_board_piece_to_stream(pos, pc);
+            }
+        }
+
+        // Write wall squares as a bitset (1 bit per square).
+        for (Rank r = pos.max_rank(); r >= RANK_1; --r)
+        {
+            for (File f = FILE_A; f <= pos.max_file(); ++f)
+            {
+                Square sq = make_square(f, r);
+                stream.write_one_bit((pos.state()->wallSquares & sq) ? 1 : 0);
             }
         }
 
@@ -337,8 +349,22 @@ namespace Stockfish::Tools {
 
                 pos.put_piece(Piece(pc), sq);
 
-                if (stream.get_cursor()> 512)
+                if (stream.get_cursor()> DATA_SIZE)
                     return 1;
+            }
+        }
+
+        // Wall squares
+        for (Rank r = pos.max_rank(); r >= RANK_1; --r)
+        {
+            for (File f = FILE_A; f <= pos.max_file(); ++f)
+            {
+                auto sq = make_square(f, r);
+                if (stream.read_one_bit())
+                {
+                    pos.st->wallSquares |= sq;
+                    pos.byTypeBB[ALL_PIECES] |= sq;
+                }
             }
         }
 

--- a/src/tools/sfen_packer.cpp
+++ b/src/tools/sfen_packer.cpp
@@ -199,13 +199,16 @@ namespace Stockfish::Tools {
             }
         }
 
-        // Write wall squares as a bitset (1 bit per square).
-        for (Rank r = pos.max_rank(); r >= RANK_1; --r)
+        if (pos.nnue_wall_index_base() >= 0)
         {
-            for (File f = FILE_A; f <= pos.max_file(); ++f)
+            // Write wall squares as a bitset (1 bit per square).
+            for (Rank r = pos.max_rank(); r >= RANK_1; --r)
             {
-                Square sq = make_square(f, r);
-                stream.write_one_bit((pos.state()->wallSquares & sq) ? 1 : 0);
+                for (File f = FILE_A; f <= pos.max_file(); ++f)
+                {
+                    Square sq = make_square(f, r);
+                    stream.write_one_bit((pos.state()->wallSquares & sq) ? 1 : 0);
+                }
             }
         }
 
@@ -354,16 +357,19 @@ namespace Stockfish::Tools {
             }
         }
 
-        // Wall squares
-        for (Rank r = pos.max_rank(); r >= RANK_1; --r)
+        if (pos.nnue_wall_index_base() >= 0)
         {
-            for (File f = FILE_A; f <= pos.max_file(); ++f)
+            // Wall squares
+            for (Rank r = pos.max_rank(); r >= RANK_1; --r)
             {
-                auto sq = make_square(f, r);
-                if (stream.read_one_bit())
+                for (File f = FILE_A; f <= pos.max_file(); ++f)
                 {
-                    pos.st->wallSquares |= sq;
-                    pos.byTypeBB[ALL_PIECES] |= sq;
+                    auto sq = make_square(f, r);
+                    if (stream.read_one_bit())
+                    {
+                        pos.st->wallSquares |= sq;
+                        pos.byTypeBB[ALL_PIECES] |= sq;
+                    }
                 }
             }
         }

--- a/src/tools/training_data_generator.cpp
+++ b/src/tools/training_data_generator.cpp
@@ -315,13 +315,8 @@ namespace Stockfish::Tools
                 const int depth = params.search_depth_min + (int)prng.rand(params.search_depth_max - params.search_depth_min + 1);
 
                 // Starting search calls init_for_search
-                Value eval_value = VALUE_ZERO;
-                Value qsearch_value = VALUE_ZERO;
-                if (params.eval_diff_limit >= 0)
-                {
-                    eval_value = Search::search(pos, pos.checkers() || pos.is_immediate_game_end() ? 0 : -1).first;
-                    qsearch_value = Search::search(pos, 0).first;
-                }
+                Value eval_value = Search::search(pos, pos.checkers() || pos.is_immediate_game_end() ? 0 : -1).first;
+                Value qsearch_value = Search::search(pos, 0).first;
                 auto [search_value, search_pv] = Search::search(pos, depth, 1, params.nodes);
 
                 // This has to be performed after search because it needs to know

--- a/src/tools/training_data_generator.cpp
+++ b/src/tools/training_data_generator.cpp
@@ -315,8 +315,13 @@ namespace Stockfish::Tools
                 const int depth = params.search_depth_min + (int)prng.rand(params.search_depth_max - params.search_depth_min + 1);
 
                 // Starting search calls init_for_search
-                auto [eval_value, eval_pv] = Search::search(pos, pos.checkers() || pos.is_immediate_game_end() ? 0 : -1);
-                auto [qsearch_value, qsearch_pv] = Search::search(pos, 0);
+                Value eval_value = VALUE_ZERO;
+                Value qsearch_value = VALUE_ZERO;
+                if (params.eval_diff_limit >= 0)
+                {
+                    eval_value = Search::search(pos, pos.checkers() || pos.is_immediate_game_end() ? 0 : -1).first;
+                    qsearch_value = Search::search(pos, 0).first;
+                }
                 auto [search_value, search_pv] = Search::search(pos, depth, 1, params.nodes);
 
                 // This has to be performed after search because it needs to know
@@ -360,11 +365,13 @@ namespace Stockfish::Tools
 
                 // Filter for static positions using abs(qsearch_value - eval_value)
                 // sync_cout << pos.fen() << " | " << search_value << " | " << qsearch_value << " | " << eval_value << sync_endl;
+                const bool eval_diff_ok = params.eval_diff_limit < 0
+                                       || std::abs(qsearch_value - eval_value) <= params.eval_diff_limit;
                 if (ply >= params.write_minply && !was_seen_before(pos)
                     && !pos.checkers() && pos.nnue_applicable()
-                    && std::abs(qsearch_value - eval_value) <= params.eval_diff_limit
-                    && !(params.filter_captures && pos.capture(search_pv[0]))
-                    && !(params.filter_checks && pos.gives_check(search_pv[0]))
+                    && eval_diff_ok
+                    && !(params.filter_captures && pos.capture(search_pv[0]))   
+                    && !(params.filter_checks && pos.gives_check(search_pv[0])) 
                     && !(params.filter_promotions && (type_of(search_pv[0]) == PROMOTION || type_of(search_pv[0]) == PIECE_PROMOTION)))
                 {
                     auto& psv = packed_sfens.emplace_back();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -393,7 +393,7 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     std::cerr << "Writing config for variant " + variant << std::endl;
 
       const int dataSize = (v->maxFile + 1) * (v->maxRank + 1) /* board squares */
-                          + (v->maxFile + 1) * (v->maxRank + 1) /* wall bitset */
+                          + (nnueHasWalls ? (v->maxFile + 1) * (v->maxRank + 1) : 0) /* wall bitset */
                           + v->nnueMaxPieces * 5
                           + popcount(v->pieceTypes) * 2 * 5 + 50 > 512 ? 1024 : 512;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -391,8 +391,10 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     const Variant* v = variants.find(variant)->second;
     std::cerr << "Writing config for variant " + variant << std::endl;
 
-    const int dataSize = (v->maxFile + 1) * (v->maxRank + 1) + v->nnueMaxPieces * 5
-                        + popcount(v->pieceTypes) * 2 * 5 + 50 > 512 ? 1024 : 512;
+      const int dataSize = (v->maxFile + 1) * (v->maxRank + 1) /* board squares */
+                          + (v->maxFile + 1) * (v->maxRank + 1) /* wall bitset */
+                          + v->nnueMaxPieces * 5
+                          + popcount(v->pieceTypes) * 2 * 5 + 50 > 512 ? 1024 : 512;
 
     if (dataSize > DATA_SIZE)
         std::cerr << std::endl << "Warning: Recommended training data size " << dataSize

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -389,6 +389,7 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     }
 
     const Variant* v = variants.find(variant)->second;
+    const bool nnueHasWalls = v->nnueWallIndexBase >= 0;
     std::cerr << "Writing config for variant " + variant << std::endl;
 
       const int dataSize = (v->maxFile + 1) * (v->maxRank + 1) /* board squares */
@@ -411,6 +412,7 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     << "#define PIECE_TYPES " << popcount(v->pieceTypes) << std::endl
     << "#define PIECE_COUNT " << v->nnueMaxPieces << std::endl
     << "#define POCKETS " << (v->nnueUsePockets ? "true" : "false") << std::endl
+    << "#define HAS_WALLS " << (nnueHasWalls ? "true" : "false") << std::endl
     << "#define KING_SQUARES " << v->nnueKingSquare << std::endl
     << "#define DATA_SIZE " << DATA_SIZE << std::endl;
 
@@ -429,8 +431,9 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     << "KING_SQUARES = " << v->nnueKingSquare << std::endl
     << "PIECE_TYPES = " << popcount(v->pieceTypes) << std::endl
     << "PIECES = 2 * PIECE_TYPES" << std::endl
-    << "USE_POCKETS = " << (v->nnueUsePockets ? "True" : "False") << std::endl
+    << "USE_POCKETS = " << (v->nnueUsePockets ? "True" : "False") << std::endl  
     << "POCKETS = 2 * FILES if USE_POCKETS else 0" << std::endl
+    << "HAS_WALLS = " << (nnueHasWalls ? "True" : "False") << std::endl
     << std::endl
     << "PIECE_VALUES = {" << std::endl;
     for (PieceSet ps = v->pieceTypes; ps;)

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2006,11 +2006,13 @@ Variant* Variant::conclude() {
     }
     // We can not use popcount here yet, as the lookup tables are initialized after the variants
     int nnueSquares = (maxRank + 1) * (maxFile + 1);
-    nnueUsePockets = (pieceDrops && (capturesToHand || (!mustDrop && std::bitset<64>(pieceTypes).count() != 1))) || seirawanGating;
-    int nnuePockets = nnueUsePockets ? 2 * int(maxFile + 1) : 0;
-    int nnueNonDropPieceIndices = (2 * std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnueSquares;
-    int nnuePieceIndices = nnueNonDropPieceIndices + 2 * (std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnuePockets;
-    int i = 0;
+      nnueUsePockets = (pieceDrops && (capturesToHand || (!mustDrop && std::bitset<64>(pieceTypes).count() != 1))) || seirawanGating;
+      int nnuePockets = nnueUsePockets ? 2 * int(maxFile + 1) : 0;
+      int nnueNonDropPieceIndices = (2 * std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnueSquares;
+      int nnuePieceIndices = nnueNonDropPieceIndices + 2 * (std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnuePockets;
+      nnueWallIndexBase = nnuePieceIndices;
+      nnuePieceIndices += nnueSquares;
+      int i = 0;
     for (PieceSet ps = pieceTypes; ps;)
     {
         // Make sure that the nnueKing type gets the last index, since the NNUE architecture relies on that

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2010,8 +2010,12 @@ Variant* Variant::conclude() {
       int nnuePockets = nnueUsePockets ? 2 * int(maxFile + 1) : 0;
       int nnueNonDropPieceIndices = (2 * std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnueSquares;
       int nnuePieceIndices = nnueNonDropPieceIndices + 2 * (std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnuePockets;
-      nnueWallIndexBase = nnuePieceIndices;
-      nnuePieceIndices += nnueSquares;
+      bool nnueHasWalls = wallingRule != NO_WALLING
+                       || petrifyOnCaptureTypes != NO_PIECE_SET
+                       || startFen.find('*') != std::string::npos;
+      nnueWallIndexBase = nnueHasWalls ? nnuePieceIndices : -1;
+      if (nnueHasWalls)
+          nnuePieceIndices += nnueSquares;
       int i = 0;
     for (PieceSet ps = pieceTypes; ps;)
     {

--- a/src/variant.h
+++ b/src/variant.h
@@ -168,9 +168,10 @@ struct Variant {
   bool fastAttacks2 = true;
   std::string nnueAlias = "";
   PieceType nnueKing = KING;
-  int pieceIndex[PIECE_TYPE_NB];
-  int nnueDimensions;
-  bool nnueUsePockets;
+    int pieceIndex[PIECE_TYPE_NB];
+    int nnueDimensions;
+    int nnueWallIndexBase;
+    bool nnueUsePockets;
   int pieceSquareIndex[COLOR_NB][PIECE_NB];
   int pieceHandIndex[COLOR_NB][PIECE_NB];
   int kingSquareIndex[SQUARE_NB];

--- a/src/variant.h
+++ b/src/variant.h
@@ -169,9 +169,9 @@ struct Variant {
   std::string nnueAlias = "";
   PieceType nnueKing = KING;
     int pieceIndex[PIECE_TYPE_NB];
-    int nnueDimensions;
-    int nnueWallIndexBase;
-    bool nnueUsePockets;
+    int nnueDimensions = 0;
+    int nnueWallIndexBase = -1;
+    bool nnueUsePockets = false;
   int pieceSquareIndex[COLOR_NB][PIECE_NB];
   int pieceHandIndex[COLOR_NB][PIECE_NB];
   int kingSquareIndex[SQUARE_NB];


### PR DESCRIPTION
 ## Summary
  - Pack/unpack a wall-square bitset in PackedSfen.
  - Extend HalfKAv2Variants feature layout/hash to include walls.
  - Add NNUE wall index base and update trainer_config sizing hint.

  ## Compatibility
  - Packed data format changed; regenerate .bin data.