### PR TITLE
Tools: pack potion data and emit HAS_POTIONS in trainer_config

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -1,13 +1,7 @@
 name: fairy
 on:
   push:
-    branches:
-      - master
-      - tools
   pull_request:
-    branches:
-      - master
-      - tools
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         arch: ["x86-64"]
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ master, tools ]
   pull_request:
-    branches: [ master, tools ]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -1,14 +1,7 @@
 name: Stockfish
 on:
   push:
-    branches:
-      - master
-      - tools
-      - github_ci
   pull_request:
-    branches:
-      - master
-      - tools
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-13]
+        os: [ubuntu-24.04, windows-2022, macos-15-intel]
 
     steps:
       - uses: actions/checkout@v5

--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -875,6 +875,80 @@ inline Validation check_pocket_info(const std::string& fenBoard, int nbRanks, co
     return NOK;
 }
 
+inline Validation check_potion_square(const std::string& squareToken, const Variant* v) {
+    if (squareToken == "-")
+        return OK;
+    if (squareToken.size() < 2)
+        return NOK;
+    char fileChar = squareToken[0];
+    if (!isalpha(fileChar))
+        return NOK;
+    int fileIndex = tolower(fileChar) - 'a';
+    if (fileIndex < 0 || fileIndex > v->maxFile)
+        return NOK;
+    int rankIndex = 0;
+    for (size_t i = 1; i < squareToken.size(); ++i)
+    {
+        if (!isdigit(squareToken[i]))
+            return NOK;
+        rankIndex = rankIndex * 10 + (squareToken[i] - '0');
+    }
+    if (rankIndex < 1 || rankIndex > v->maxRank + 1)
+        return NOK;
+    return OK;
+}
+
+inline Validation check_potion_info(const std::string& potionField, const Variant* v) {
+    if (potionField.size() < 2 || potionField.front() != '{' || potionField.back() != '}')
+        return NOK;
+    std::string state = potionField.substr(1, potionField.size() - 2);
+    if (state.empty())
+        return OK;
+    size_t start = 0;
+    while (start < state.size())
+    {
+        size_t end = state.find(',', start);
+        std::string entry = state.substr(start, end == std::string::npos ? end : end - start);
+        if (entry.size() < 4)
+            return NOK;
+        char pieceChar = entry[0];
+        if (!isalpha(pieceChar))
+            return NOK;
+        bool isPotionPiece = false;
+        for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+        {
+            PieceType potionPiece = v->potionPiece[pt];
+            if (potionPiece == NO_PIECE_TYPE)
+                continue;
+            char expected = v->pieceToChar[make_piece(WHITE, potionPiece)];
+            if (tolower(expected) == tolower(pieceChar))
+            {
+                isPotionPiece = true;
+                break;
+            }
+        }
+        if (!isPotionPiece)
+            return NOK;
+        size_t at = entry.find('@', 1);
+        size_t colon = entry.find(':', at == std::string::npos ? 0 : at + 1);
+        if (at == std::string::npos || colon == std::string::npos || at + 1 > colon)
+            return NOK;
+        std::string squareToken = entry.substr(at + 1, colon - at - 1);
+        if (check_potion_square(squareToken, v) == NOK)
+            return NOK;
+        std::string cooldownToken = entry.substr(colon + 1);
+        if (cooldownToken.empty())
+            return NOK;
+        for (char c : cooldownToken)
+            if (!isdigit(c))
+                return NOK;
+        if (end == std::string::npos)
+            break;
+        start = end + 1;
+    }
+    return OK;
+}
+
 inline int piece_count(const std::string& fenBoard, Color c, PieceType pt, const Variant* v) {
     return std::count(fenBoard.begin(), fenBoard.end(), v->pieceToChar[make_piece(c, pt)]);
 }
@@ -1002,6 +1076,13 @@ inline FenValidation validate_fen(const std::string& fen, const Variant* v, bool
 
     std::vector<std::string> fenParts = get_fen_parts(fen, ' ');
     std::vector<std::string> startFenParts = get_fen_parts(v->startFen, ' ');
+
+    if (v->potions && fenParts.size() >= 2 && fenParts[1].size() >= 2 && fenParts[1].front() == '{' && fenParts[1].back() == '}')
+    {
+        if (check_potion_info(fenParts[1], v) == NOK)
+            return FEN_INVALID_CHAR;
+        fenParts.erase(fenParts.begin() + 1);
+    }
 
     // check for number of parts
     const unsigned int maxNumberFenParts = 6 + v->checkCounting;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -239,15 +239,13 @@ Entry* probe(const Position& pos) {
       {
           if (!pos.count<PAWN>(BLACK))
           {
-              assert(pos.count<PAWN>(WHITE) >= 2);
-
-              e->scalingFunction[WHITE] = &ScaleKPsK[WHITE];
+              if (pos.count<PAWN>(WHITE) >= 2)
+                  e->scalingFunction[WHITE] = &ScaleKPsK[WHITE];
           }
           else if (!pos.count<PAWN>(WHITE))
           {
-              assert(pos.count<PAWN>(BLACK) >= 2);
-
-              e->scalingFunction[BLACK] = &ScaleKPsK[BLACK];
+              if (pos.count<PAWN>(BLACK) >= 2)
+                  e->scalingFunction[BLACK] = &ScaleKPsK[BLACK];
           }
           else if (pos.count<PAWN>(WHITE) == 1 && pos.count<PAWN>(BLACK) == 1)
           {

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -85,7 +85,7 @@ namespace {
                             if (color_of(target) == ~us)
                             {
                                 int bonus = int(CapturePieceValue[MG][target]);
-                                if (type_of(target) == pos.king_type())
+                                if (type_of(target) == pos.royal_piece_type())
                                     bonus += PotionKingBonus;
                                 scores[blocker] += bonus;
                             }
@@ -216,6 +216,7 @@ namespace {
     constexpr Direction Up       = pawn_push(Us);
     constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
+    const PieceType royal = pos.royal_piece_type();
 
     const bool allowFriendlyCaptures = pos.self_capture()
                                     && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS);
@@ -228,7 +229,7 @@ namespace {
     const Bitboard frozen     = pos.freeze_squares();
     const Bitboard pawns      = pos.pieces(Us, PAWN) & ~frozen;
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
-    const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, KING);
+    const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, royal);
     const Bitboard capturable = pos.board_bb(Us, PAWN)
                               & (allowFriendlyCaptures ? (pos.pieces(Them) | friendlyCapturable)
                                                        :  pos.pieces(Them));
@@ -258,12 +259,12 @@ namespace {
         blc &= ~standardPromotionZone;
     }
 
-    if (Type == QUIET_CHECKS && pos.count<KING>(Them))
+    if (Type == QUIET_CHECKS && pos.count(Them, royal))
     {
         // To make a quiet check, you either make a direct check by pushing a pawn
         // or push a blocker pawn that is not on the same file as the enemy king.
         // Discovered check promotion has been already generated amongst the captures.
-        Square ksq = pos.square<KING>(Them);
+        Square ksq = pos.square(Them, royal);
         Bitboard dcCandidatePawns = pos.blockers_for_king(Them) & ~file_bb(ksq);
         b1 &= pawn_attacks_bb(Them, ksq) | shift<   Up>(dcCandidatePawns);
         b2 &= pawn_attacks_bb(Them, ksq) | shift<Up+Up>(dcCandidatePawns);
@@ -473,7 +474,8 @@ namespace {
     static_assert(Type != LEGAL, "Unsupported type in generate_all()");
 
     constexpr bool Checks = Type == QUIET_CHECKS; // Reduce template instantiations
-    const Square ksq = pos.count<KING>(Us) ? pos.square<KING>(Us) : SQ_NONE;
+    const PieceType royal = pos.royal_piece_type();
+    const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     Bitboard target;
     Bitboard captureTarget = Type == EVASIONS ? ~pos.pieces(Us) : Bitboard(0);
     Bitboard jumpForbidden = pos.spell_jump_removed();
@@ -492,7 +494,7 @@ namespace {
                 target = ~pos.pieces(Us);
             // Leaper attacks can not be blocked
             Square checksq = lsb(pos.checkers());
-            if (LeaperAttacks[~Us][type_of(pos.piece_on(checksq))][checksq] & pos.square<KING>(Us))
+            if (LeaperAttacks[~Us][type_of(pos.piece_on(checksq))][checksq] & ksq)
                 target = pos.checkers();
         }
 
@@ -505,10 +507,10 @@ namespace {
         if (jumpForbidden)
             captureTarget &= ~jumpForbidden;
         if (pos.self_capture() && (Type == NON_EVASIONS || Type == CAPTURES))
-            captureTarget |= pos.pieces(Us) & ~pos.pieces(Us, KING);
+            captureTarget |= pos.pieces(Us) & ~pos.pieces(Us, royal);
 
         moveList = generate_pawn_moves<Us, Type>(pos, moveList, target);
-        for (PieceSet ps = pos.piece_types() & ~(piece_set(PAWN) | KING); ps;)
+        for (PieceSet ps = pos.piece_types() & ~(piece_set(PAWN) | royal); ps;)
             moveList = generate_moves<Us, Type>(pos, moveList, pop_lsb(ps), target, captureTarget);
         // generate drops
         if (pos.piece_drops() && Type != CAPTURES && (pos.can_drop(Us, ALL_PIECES) || pos.two_boards()))
@@ -516,7 +518,7 @@ namespace {
                 moveList = generate_drops<Us, Type>(pos, moveList, pop_lsb(ps), target & ~pos.pieces(~Us));
 
         // Castling with non-king piece
-        if (!pos.count<KING>(Us) && Type != CAPTURES && pos.can_castle(Us & ANY_CASTLING))
+        if (!pos.count(Us, royal) && Type != CAPTURES && pos.can_castle(Us & ANY_CASTLING))
         {
             Square from = pos.castling_king_square(Us);
             for(CastlingRights cr : { Us & KING_SIDE, Us & QUEEN_SIDE } )
@@ -527,9 +529,9 @@ namespace {
         // Special moves
         if (pos.cambodian_moves() && pos.gates(Us) && Type != CAPTURES)
         {
-            if (Type != EVASIONS && (pos.pieces(Us, KING) & pos.gates(Us)))
+            if (Type != EVASIONS && (pos.pieces(Us, royal) & pos.gates(Us)))
             {
-                Square from = pos.square<KING>(Us);
+                Square from = pos.square(Us, royal);
                 Bitboard b = PseudoAttacks[WHITE][KNIGHT][from] & rank_bb(rank_of(from + (Us == WHITE ? NORTH : SOUTH)))
                     & target & ~pos.pieces();
                 while (b)
@@ -547,7 +549,7 @@ namespace {
         }
 
         // Workaround for passing: Execute a non-move with any piece
-        if (pos.pass(Us) && !pos.count<KING>(Us) && pos.pieces(Us))
+        if (pos.pass(Us) && !pos.count(Us, royal) && pos.pieces(Us))
             *moveList++ = make<SPECIAL>(lsb(pos.pieces(Us)), lsb(pos.pieces(Us)));
 
         //if "wall or move", generate walling action with null move
@@ -558,13 +560,13 @@ namespace {
     }
 
     // King moves
-    if (pos.count<KING>(Us) && (!Checks || pos.blockers_for_king(~Us) & ksq))
+    if (pos.count(Us, royal) && (!Checks || pos.blockers_for_king(~Us) & ksq))
     {
-        Bitboard kingAttacks = pos.attacks_from(Us, KING, ksq) & pos.pieces();
-        Bitboard kingMoves   = pos.moves_from  (Us, KING, ksq) & ~pos.pieces();
+        Bitboard kingAttacks = pos.attacks_from(Us, royal, ksq) & pos.pieces();
+        Bitboard kingMoves   = pos.moves_from  (Us, royal, ksq) & ~pos.pieces();
         Bitboard kingCaptureMask = Type == EVASIONS ? ~pos.pieces(Us) : captureTarget;
         if (Type == EVASIONS && pos.self_capture())
-            kingCaptureMask |= pos.pieces(Us) & ~pos.pieces(Us, KING);
+            kingCaptureMask |= pos.pieces(Us) & ~pos.pieces(Us, royal);
         Bitboard kingQuietMask = Type == EVASIONS ? ~pos.pieces(Us) : target;
         Bitboard b = (kingAttacks & kingCaptureMask) | (kingMoves & kingQuietMask);
         while (b)
@@ -590,10 +592,11 @@ namespace {
         return baseEnd;
 
     const Variant* var = pos.variant();
+    const PieceType royal = pos.royal_piece_type();
     ExtMove* cur = baseEnd;
     const Bitboard baseFrozen = pos.freeze_squares();
     const Bitboard allPieces = pos.pieces();
-    const Square ksq = pos.count<KING>(Us) ? pos.square<KING>(Us) : SQ_NONE;
+    const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS
                            || !more_than_one(pos.checkers() & ~pos.non_sliding_riders());
     bool baseMovesSorted = false;
@@ -707,8 +710,7 @@ namespace {
                     target = ~pos.pieces(Us);
                 // Leaper attacks can not be blocked
                 Square checksq = lsb(pos.checkers());
-                if (LeaperAttacks[~Us][type_of(pos.piece_on(checksq))][checksq]
-                    & pos.square<KING>(Us))
+                if (LeaperAttacks[~Us][type_of(pos.piece_on(checksq))][checksq] & ksq)
                     target = pos.checkers();
             }
 
@@ -719,11 +721,11 @@ namespace {
             Bitboard captureTarget = target;
             captureTarget &= ~jumpRemoved;
             if (pos.self_capture() && (Type == NON_EVASIONS || Type == CAPTURES))
-                captureTarget |= pos.pieces(Us) & ~pos.pieces(Us, KING);
+                captureTarget |= pos.pieces(Us) & ~pos.pieces(Us, royal);
 
             static thread_local ExtMove extraMoves[MAX_MOVES];
             ExtMove* extraEnd = extraMoves;
-            for (PieceSet ps = pos.piece_types() & ~(piece_set(PAWN) | KING); ps;)
+            for (PieceSet ps = pos.piece_types() & ~(piece_set(PAWN) | royal); ps;)
             {
                 PieceType sliderPt = pop_lsb(ps);
                 if (!(MoveRiderTypes[0][sliderPt] | MoveRiderTypes[1][sliderPt]
@@ -779,8 +781,7 @@ namespace {
                     Bitboard enemies = zone & pos.pieces(~Us);
                     while (enemies)
                         score += int(CapturePieceValue[MG][pos.piece_on(pop_lsb(enemies))]);
-                    PieceType kingType = pos.king_type();
-                    if (kingType != NO_PIECE_TYPE && (zone & pos.pieces(~Us, kingType)))
+                    if (royal != NO_PIECE_TYPE && (zone & pos.pieces(~Us, royal)))
                         score += PotionKingBonus;
                 }
                 else

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -525,13 +525,15 @@ namespace {
   }
 
   template<Color Us, GenType Type>
-  ExtMove* generate_potion_moves(const Position& pos, ExtMove* baseEnd) {
+  ExtMove* generate_potion_moves(const Position& pos, ExtMove* baseStart, ExtMove* baseEnd) {
 
     if (!pos.potions_enabled())
         return baseEnd;
 
     const Variant* var = pos.variant();
     ExtMove* cur = baseEnd;
+    const Bitboard baseFrozen = pos.freeze_squares();
+    const Bitboard allPieces = pos.pieces();
 
     for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
     {
@@ -544,22 +546,54 @@ namespace {
 
         Bitboard candidates = pos.board_bb();
         if (!var->potionDropOnOccupied)
-            candidates &= ~pos.pieces();
+            candidates &= ~allPieces;
 
         if (potion == Variant::POTION_JUMP)
-            candidates &= pos.pieces();
+            candidates &= allPieces;
 
         while (candidates)
         {
             Square gate = pop_lsb(candidates);
 
-            if (potion == Variant::POTION_JUMP && !(pos.pieces() & gate))
+            if (potion == Variant::POTION_JUMP && !(allPieces & gate))
                 continue;
 
-            Bitboard freezeExtra = potion == Variant::POTION_FREEZE ? pos.freeze_zone_from_square(gate) : Bitboard(0);
-            Bitboard jumpRemoved = potion == Variant::POTION_JUMP ? square_bb(gate) : Bitboard(0);
+            if (potion == Variant::POTION_FREEZE)
+            {
+                // Freeze only restricts moves, so reuse the base list and filter by frozen squares.
+                Bitboard frozen = baseFrozen | pos.freeze_zone_from_square(gate);
+                ExtMove* write = cur;
+                for (ExtMove* it = baseStart; it != baseEnd; ++it)
+                {
+                    Move base = it->move;
+                    if (is_gating(base))
+                        continue;
 
-            SpellContextGuard guard(pos, freezeExtra, jumpRemoved);
+                    MoveType mt = type_of(base);
+                    if (mt != NORMAL && mt != CASTLING)
+                        continue;
+
+                    if (frozen & from_sq(base))
+                        continue;
+                    if (mt == CASTLING && (frozen & to_sq(base)))
+                        continue;
+
+                    Move gatingMove = mt == NORMAL
+                                      ? make_gating<NORMAL>(from_sq(base), to_sq(base), potionPiece, gate)
+                                      : make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate);
+
+                    write->move = gatingMove;
+                    write->value = it->value;
+                    ++write;
+                }
+
+                cur = write;
+                continue;
+            }
+
+            Bitboard jumpRemoved = square_bb(gate);
+
+            SpellContextGuard guard(pos, Bitboard(0), jumpRemoved);
 
             ExtMove* potionStart = cur;
             cur = generate_all_impl<Us, Type>(pos, cur);
@@ -595,7 +629,7 @@ namespace {
   ExtMove* generate_all(const Position& pos, ExtMove* moveList) {
 
     ExtMove* baseEnd = generate_all_impl<Us, Type>(pos, moveList);
-    return generate_potion_moves<Us, Type>(pos, baseEnd);
+    return generate_potion_moves<Us, Type>(pos, moveList, baseEnd);
   }
 
 } // namespace

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1007,8 +1007,9 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 
   ExtMove* cur = moveList;
 
-  ExtMove* end = pos.checkers() ? generate<EVASIONS    >(pos, moveList)
-                                : generate<NON_EVASIONS>(pos, moveList);
+  bool needsEvasion = pos.checkers() && !pos.allow_self_check();
+  ExtMove* end = needsEvasion ? generate<EVASIONS    >(pos, moveList)
+                              : generate<NON_EVASIONS>(pos, moveList);
   while (cur != end)
       if (!pos.legal(*cur) || pos.virtual_drop(*cur))
           *cur = (--end)->move;
@@ -1017,7 +1018,7 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 
   // In check, some potion moves only become evasions because of the gate effect.
   // Generate extra potion moves from the full non-evasion base list and filter by legality.
-  if (pos.checkers() && pos.potions_enabled())
+  if (needsEvasion && pos.potions_enabled())
   {
       static thread_local ExtMove baseMoves[MAX_MOVES];
       ExtMove* baseEnd = generate_base(NON_EVASIONS, pos, baseMoves);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -890,7 +890,9 @@ template<GenType Type>
 ExtMove* generate(const Position& pos, ExtMove* moveList) {
 
   static_assert(Type != LEGAL, "Unsupported type in generate()");
-  assert((Type == EVASIONS) == (bool)pos.checkers());
+  const bool needsEvasion = pos.checkers() && !pos.allow_self_check();
+  assert((Type == EVASIONS) == needsEvasion);
+  (void)needsEvasion;
 
   Color us = pos.side_to_move();
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -226,7 +226,7 @@ namespace {
     const Bitboard doubleStepRegion = pos.double_step_region(Us);
     const Bitboard tripleStepRegion = pos.triple_step_region(Us);
 
-    const Bitboard frozen     = pos.freeze_squares();
+    const Bitboard frozen     = pos.freeze_move_squares();
     const Bitboard pawns      = pos.pieces(Us, PAWN) & ~frozen;
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
     const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, royal);
@@ -375,7 +375,7 @@ namespace {
     assert(Pt != KING && Pt != PAWN);
 
     Bitboard bb = pos.pieces(Us, Pt);
-    Bitboard frozen = pos.freeze_squares();
+    Bitboard frozen = pos.freeze_move_squares();
 
     const bool allowFriendlyCaptures = pos.self_capture()
                                     && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS);
@@ -594,7 +594,7 @@ namespace {
     const Variant* var = pos.variant();
     const PieceType royal = pos.royal_piece_type();
     ExtMove* cur = baseEnd;
-    const Bitboard baseFrozen = pos.freeze_squares();
+    const Bitboard baseFrozen = pos.freeze_move_squares();
     const Bitboard allPieces = pos.pieces();
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS
@@ -631,8 +631,8 @@ namespace {
 
             if (potion == Variant::POTION_FREEZE)
             {
-                // Freeze only restricts moves, so reuse the base list and filter by frozen squares.
-                Bitboard frozen = baseFrozen | pos.freeze_zone_from_square(gate);
+                // New freeze zones apply after the move, so only existing frozen squares block it.
+                Bitboard frozen = baseFrozen;
                 ExtMove* write = cur;
                 for (ExtMove* it = baseStart; it != baseEnd; ++it)
                 {

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -624,6 +624,15 @@ namespace {
         if (potion == Variant::POTION_JUMP)
             candidates &= allPieces;
 
+        ExtMove* freezeStart = baseStart;
+        ExtMove* freezeEnd = baseEnd;
+        static thread_local ExtMove freezeMoves[MAX_MOVES];
+        if (Type == EVASIONS && potion == Variant::POTION_FREEZE)
+        {
+            freezeStart = freezeMoves;
+            freezeEnd = generate_all_impl<Us, NON_EVASIONS>(pos, freezeStart);
+        }
+
         auto generate_for_gate = [&](Square gate, int gateScore) {
 
             if (potion == Variant::POTION_JUMP && !(allPieces & gate))
@@ -631,13 +640,15 @@ namespace {
 
             if (potion == Variant::POTION_FREEZE)
             {
-                // Freeze only restricts moves, so reuse the base list and filter by frozen squares.
-                Bitboard frozen = baseFrozen | pos.freeze_zone_from_square(gate);
+                // New freeze zones apply after the move, so only existing frozen squares block it.
+                Bitboard frozen = baseFrozen;
                 ExtMove* write = cur;
-                for (ExtMove* it = baseStart; it != baseEnd; ++it)
+                for (ExtMove* it = freezeStart; it != freezeEnd; ++it)
                 {
                     Move base = it->move;
                     if (is_gating(base))
+                        continue;
+                    if (from_sq(base) == gate)
                         continue;
 
                     MoveType mt = type_of(base);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -228,11 +228,15 @@ namespace {
 
     const Bitboard frozen     = pos.freeze_squares(Us);
     const Bitboard pawns      = pos.pieces(Us, PAWN) & ~frozen;
-    const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
+    const Bitboard jumpMask   = pos.potions_enabled() ? pos.jump_squares(Us) : Bitboard(0);
+    const Bitboard occupied   = pos.pieces() & ~jumpMask;
+    const Bitboard movable    = pos.board_bb(Us, PAWN) & ~occupied;
     const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, royal);
-    const Bitboard capturable = pos.board_bb(Us, PAWN)
-                              & (allowFriendlyCaptures ? (pos.pieces(Them) | friendlyCapturable)
-                                                       :  pos.pieces(Them));
+    Bitboard capturable = pos.board_bb(Us, PAWN)
+                        & (allowFriendlyCaptures ? (pos.pieces(Them) | friendlyCapturable)
+                                                 :  pos.pieces(Them));
+    if (jumpMask)
+        capturable &= ~jumpMask;
 
     target = Type == EVASIONS ? target : AllSquares;
 
@@ -599,7 +603,6 @@ namespace {
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS
                            || !more_than_one(pos.checkers() & ~pos.non_sliding_riders());
-    const bool needsEvasion = pos.checkers() && !pos.allow_self_check();
     bool baseMovesSorted = false;
     Move baseMoves[MAX_MOVES];
     int baseCount = 0;
@@ -646,12 +649,8 @@ namespace {
 
             if (potion == Variant::POTION_FREEZE)
             {
-                // Pieces already adjacent (orthogonally) to the new freeze center are immobilized.
-                const Bitboard gateBb = square_bb(gate);
-                const Bitboard newZone =
-                    (gateBb | shift<NORTH>(gateBb) | shift<SOUTH>(gateBb)
-                            | shift<EAST>(gateBb) | shift<WEST>(gateBb))
-                    & pos.board_bb();
+                // Pieces already inside the new freeze block zone cannot be moved on the casting ply.
+                const Bitboard newBlockZone = pos.freeze_block_zone_from_square(gate);
                 const Bitboard frozen = baseFrozen;
                 ExtMove* write = cur;
                 for (ExtMove* it = freezeStart; it != freezeEnd; ++it)
@@ -666,7 +665,7 @@ namespace {
                     if (mt != NORMAL && mt != CASTLING)
                         continue;
 
-                    if (!needsEvasion && (newZone & from_sq(base)))
+                    if (newBlockZone & from_sq(base))
                         continue;
                     if (frozen & from_sq(base))
                         continue;
@@ -759,6 +758,7 @@ namespace {
                     continue;
                 extraEnd = generate_moves<Us, Type>(pos, extraEnd, sliderPt, target, captureTarget);
             }
+            extraEnd = generate_pawn_moves<Us, Type>(pos, extraEnd, target);
 
             write = cur;
             for (ExtMove* it = extraMoves; it != extraEnd; ++it)
@@ -1031,9 +1031,8 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
       else
           ++cur;
 
-  // In check, some potion moves only become evasions because of the gate effect.
-  // Generate extra potion moves from the full non-evasion base list and filter by legality.
-  if (needsEvasion && pos.potions_enabled())
+  // Add potion moves, filtering by legality and avoiding duplicates.
+  if (pos.potions_enabled())
   {
       static thread_local ExtMove baseMoves[MAX_MOVES];
       ExtMove* baseEnd = generate_base(NON_EVASIONS, pos, baseMoves);
@@ -1042,7 +1041,7 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
       for (ExtMove* it = baseEnd; it != potionEnd; ++it)
       {
           Move m = it->move;
-          if (type_of(m) == CASTLING)
+          if (needsEvasion && type_of(m) == CASTLING)
               continue;
           if (!pos.pseudo_legal(m))
               continue;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -599,6 +599,7 @@ namespace {
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS
                            || !more_than_one(pos.checkers() & ~pos.non_sliding_riders());
+    const bool needsEvasion = pos.checkers() && !pos.allow_self_check();
     bool baseMovesSorted = false;
     Move baseMoves[MAX_MOVES];
     int baseCount = 0;
@@ -645,8 +646,13 @@ namespace {
 
             if (potion == Variant::POTION_FREEZE)
             {
-                // New freeze zones apply after the move, so only existing frozen squares block it.
-                Bitboard frozen = baseFrozen;
+                // Pieces already adjacent (orthogonally) to the new freeze center are immobilized.
+                const Bitboard gateBb = square_bb(gate);
+                const Bitboard newZone =
+                    (gateBb | shift<NORTH>(gateBb) | shift<SOUTH>(gateBb)
+                            | shift<EAST>(gateBb) | shift<WEST>(gateBb))
+                    & pos.board_bb();
+                const Bitboard frozen = baseFrozen;
                 ExtMove* write = cur;
                 for (ExtMove* it = freezeStart; it != freezeEnd; ++it)
                 {
@@ -660,6 +666,8 @@ namespace {
                     if (mt != NORMAL && mt != CASTLING)
                         continue;
 
+                    if (!needsEvasion && (newZone & from_sq(base)))
+                        continue;
                     if (frozen & from_sq(base))
                         continue;
                     if (mt == CASTLING && (frozen & to_sq(base)))

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -16,6 +16,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 #include <cassert>
 
 #include "movegen.h"
@@ -534,6 +535,12 @@ namespace {
     ExtMove* cur = baseEnd;
     const Bitboard baseFrozen = pos.freeze_squares();
     const Bitboard allPieces = pos.pieces();
+    const Square ksq = pos.count<KING>(Us) ? pos.square<KING>(Us) : SQ_NONE;
+    const bool allowNonKing = Type != EVASIONS
+                           || !more_than_one(pos.checkers() & ~pos.non_sliding_riders());
+    bool baseMovesSorted = false;
+    Move baseMoves[MAX_MOVES];
+    int baseCount = 0;
 
     for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
     {
@@ -593,13 +600,8 @@ namespace {
 
             Bitboard jumpRemoved = square_bb(gate);
 
-            SpellContextGuard guard(pos, Bitboard(0), jumpRemoved);
-
-            ExtMove* potionStart = cur;
-            cur = generate_all_impl<Us, Type>(pos, cur);
-
-            ExtMove* write = potionStart;
-            for (ExtMove* it = potionStart; it != cur; ++it)
+            ExtMove* write = cur;
+            for (ExtMove* it = baseStart; it != baseEnd; ++it)
             {
                 Move base = it->move;
                 if (is_gating(base))
@@ -609,10 +611,82 @@ namespace {
                 if (mt != NORMAL && mt != CASTLING)
                     continue;
 
+                if (to_sq(base) == gate)
+                    continue;
+
                 Move gatingMove = mt == NORMAL
                                   ? make_gating<NORMAL>(from_sq(base), to_sq(base), potionPiece, gate)
                                   : make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate);
 
+                write->move = gatingMove;
+                write->value = it->value;
+                ++write;
+            }
+
+            cur = write;
+            if (!allowNonKing)
+                continue;
+
+            if (!baseMovesSorted)
+            {
+                for (ExtMove* it = baseStart; it != baseEnd; ++it)
+                    baseMoves[baseCount++] = it->move;
+                std::sort(baseMoves, baseMoves + baseCount);
+                baseMovesSorted = true;
+            }
+
+            SpellContextGuard guard(pos, Bitboard(0), jumpRemoved);
+
+            Bitboard target = Type == EVASIONS     ?  between_bb(ksq, lsb(pos.checkers()))
+                            : Type == NON_EVASIONS ? ~pos.pieces( Us)
+                            : Type == CAPTURES     ?  pos.pieces(~Us)
+                                                   : ~pos.pieces(   ); // QUIETS || QUIET_CHECKS
+
+            if (Type == EVASIONS)
+            {
+                if (pos.checkers() & pos.non_sliding_riders())
+                    target = ~pos.pieces(Us);
+                // Leaper attacks can not be blocked
+                Square checksq = lsb(pos.checkers());
+                if (LeaperAttacks[~Us][type_of(pos.piece_on(checksq))][checksq]
+                    & pos.square<KING>(Us))
+                    target = pos.checkers();
+            }
+
+            // Remove inaccessible squares (outside board + wall squares)
+            target &= pos.board_bb();
+            target &= ~jumpRemoved;
+
+            Bitboard captureTarget = target;
+            captureTarget &= ~jumpRemoved;
+            if (pos.self_capture() && (Type == NON_EVASIONS || Type == CAPTURES))
+                captureTarget |= pos.pieces(Us) & ~pos.pieces(Us, KING);
+
+            static thread_local ExtMove extraMoves[MAX_MOVES];
+            ExtMove* extraEnd = extraMoves;
+            for (PieceSet ps = pos.piece_types() & ~(piece_set(PAWN) | KING); ps;)
+            {
+                PieceType sliderPt = pop_lsb(ps);
+                if (!(MoveRiderTypes[0][sliderPt] | MoveRiderTypes[1][sliderPt]
+                      | AttackRiderTypes[sliderPt]))
+                    continue;
+                extraEnd = generate_moves<Us, Type>(pos, extraEnd, sliderPt, target, captureTarget);
+            }
+
+            write = cur;
+            for (ExtMove* it = extraMoves; it != extraEnd; ++it)
+            {
+                Move base = it->move;
+                if (is_gating(base))
+                    continue;
+                if (type_of(base) != NORMAL)
+                    continue;
+                if (to_sq(base) == gate)
+                    continue;
+                if (std::binary_search(baseMoves, baseMoves + baseCount, base))
+                    continue;
+
+                Move gatingMove = make_gating<NORMAL>(from_sq(base), to_sq(base), potionPiece, gate);
                 write->move = gatingMove;
                 write->value = it->value;
                 ++write;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -226,7 +226,7 @@ namespace {
     const Bitboard doubleStepRegion = pos.double_step_region(Us);
     const Bitboard tripleStepRegion = pos.triple_step_region(Us);
 
-    const Bitboard frozen     = pos.freeze_squares();
+    const Bitboard frozen     = pos.frozen_squares(Us);
     const Bitboard pawns      = pos.pieces(Us, PAWN) & ~frozen;
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
     const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, royal);
@@ -375,7 +375,7 @@ namespace {
     assert(Pt != KING && Pt != PAWN);
 
     Bitboard bb = pos.pieces(Us, Pt);
-    Bitboard frozen = pos.freeze_squares();
+    Bitboard frozen = pos.frozen_squares(Us);
 
     const bool allowFriendlyCaptures = pos.self_capture()
                                     && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS);
@@ -594,7 +594,8 @@ namespace {
     const Variant* var = pos.variant();
     const PieceType royal = pos.royal_piece_type();
     ExtMove* cur = baseEnd;
-    const Bitboard baseFrozen = pos.freeze_squares();
+    const Bitboard baseFrozen = pos.frozen_squares(Us);
+    const Bitboard enemyFrozen = pos.frozen_squares(~Us);
     const Bitboard allPieces = pos.pieces();
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS
@@ -787,7 +788,7 @@ namespace {
             {
                 std::fill_n(freezeThreatScores, SQUARE_NB, 0);
 
-                const Bitboard frozen = baseFrozen;
+                const Bitboard frozen = enemyFrozen;
                 Bitboard attackers = pos.pieces(~Us) & ~frozen;
                 const Bitboard occ = pos.pieces();
                 const Bitboard ours = pos.pieces(Us);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -605,6 +605,8 @@ namespace {
     constexpr bool LimitPotionGates = Type == QUIETS;
     int jumpGateScores[SQUARE_NB];
     bool jumpScoresReady = false;
+    int freezeThreatScores[SQUARE_NB];
+    bool freezeThreatReady = false;
 
     for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
     {
@@ -622,7 +624,7 @@ namespace {
         if (potion == Variant::POTION_JUMP)
             candidates &= allPieces;
 
-        auto generate_for_gate = [&](Square gate) {
+        auto generate_for_gate = [&](Square gate, int gateScore) {
 
             if (potion == Variant::POTION_JUMP && !(allPieces & gate))
                 return;
@@ -652,7 +654,7 @@ namespace {
                                       : make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate);
 
                     write->move = gatingMove;
-                    write->value = it->value;
+                    write->value = gateScore;
                     ++write;
                 }
 
@@ -681,7 +683,7 @@ namespace {
                                   : make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate);
 
                 write->move = gatingMove;
-                write->value = it->value;
+                write->value = gateScore;
                 ++write;
             }
 
@@ -749,7 +751,7 @@ namespace {
 
                 Move gatingMove = make_gating<NORMAL>(from_sq(base), to_sq(base), potionPiece, gate);
                 write->move = gatingMove;
-                write->value = it->value;
+                write->value = gateScore;
                 ++write;
             }
 
@@ -770,6 +772,44 @@ namespace {
                 add_jump_gate_scores(pos, Us, QUEEN, BishopDirections, 4, jumpGateScores);
                 jumpScoresReady = true;
             }
+            else if (potion == Variant::POTION_FREEZE && !freezeThreatReady)
+            {
+                std::fill_n(freezeThreatScores, SQUARE_NB, 0);
+
+                const Bitboard frozen = baseFrozen;
+                Bitboard attackers = pos.pieces(~Us) & ~frozen;
+                const Bitboard occ = pos.pieces();
+                const Bitboard ours = pos.pieces(Us);
+                const Square ourRoyal = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
+
+                while (attackers)
+                {
+                    Square s = pop_lsb(attackers);
+                    Piece pc = pos.piece_on(s);
+                    PieceType enemyPt = type_of(pc);
+                    if (enemyPt == NO_PIECE_TYPE)
+                        continue;
+
+                    Bitboard attacks = attacks_bb(~Us, enemyPt, s, occ);
+                    Bitboard targets = attacks & ours;
+                    if (!targets && (ourRoyal == SQ_NONE || !(attacks & square_bb(ourRoyal))))
+                        continue;
+
+                    int bestValue = 0;
+                    while (targets)
+                    {
+                        Square t = pop_lsb(targets);
+                        bestValue = std::max(bestValue, int(CapturePieceValue[MG][pos.piece_on(t)]));
+                    }
+
+                    if (ourRoyal != SQ_NONE && (attacks & square_bb(ourRoyal)))
+                        bestValue += PotionKingBonus;
+
+                    freezeThreatScores[s] = bestValue;
+                }
+
+                freezeThreatReady = true;
+            }
 
             while (candidates)
             {
@@ -780,7 +820,11 @@ namespace {
                     Bitboard zone = pos.freeze_zone_from_square(gate);
                     Bitboard enemies = zone & pos.pieces(~Us);
                     while (enemies)
-                        score += int(CapturePieceValue[MG][pos.piece_on(pop_lsb(enemies))]);
+                    {
+                        Square esq = pop_lsb(enemies);
+                        score += int(CapturePieceValue[MG][pos.piece_on(esq)]);
+                        score += freezeThreatScores[esq];
+                    }
                     if (royal != NO_PIECE_TYPE && (zone & pos.pieces(~Us, royal)))
                         score += PotionKingBonus;
                 }
@@ -798,12 +842,12 @@ namespace {
             }
 
             for (int i = 0; i < gateCount; ++i)
-                generate_for_gate(gateScores[i].gate);
+                generate_for_gate(gateScores[i].gate, gateScores[i].score);
         }
         else
         {
             while (candidates)
-                generate_for_gate(pop_lsb(candidates));
+                generate_for_gate(pop_lsb(candidates), 0);
         }
     }
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -226,7 +226,7 @@ namespace {
     const Bitboard doubleStepRegion = pos.double_step_region(Us);
     const Bitboard tripleStepRegion = pos.triple_step_region(Us);
 
-    const Bitboard frozen     = pos.freeze_squares();
+    const Bitboard frozen     = pos.freeze_squares(Us);
     const Bitboard pawns      = pos.pieces(Us, PAWN) & ~frozen;
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
     const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, royal);
@@ -375,7 +375,7 @@ namespace {
     assert(Pt != KING && Pt != PAWN);
 
     Bitboard bb = pos.pieces(Us, Pt);
-    Bitboard frozen = pos.freeze_squares();
+    Bitboard frozen = pos.freeze_squares(Us);
 
     const bool allowFriendlyCaptures = pos.self_capture()
                                     && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS);
@@ -594,7 +594,7 @@ namespace {
     const Variant* var = pos.variant();
     const PieceType royal = pos.royal_piece_type();
     ExtMove* cur = baseEnd;
-    const Bitboard baseFrozen = pos.freeze_squares();
+    const Bitboard baseFrozen = pos.freeze_squares(Us);
     const Bitboard allPieces = pos.pieces();
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -226,7 +226,7 @@ namespace {
     const Bitboard doubleStepRegion = pos.double_step_region(Us);
     const Bitboard tripleStepRegion = pos.triple_step_region(Us);
 
-    const Bitboard frozen     = pos.freeze_move_squares();
+    const Bitboard frozen     = pos.freeze_squares();
     const Bitboard pawns      = pos.pieces(Us, PAWN) & ~frozen;
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
     const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, royal);
@@ -375,7 +375,7 @@ namespace {
     assert(Pt != KING && Pt != PAWN);
 
     Bitboard bb = pos.pieces(Us, Pt);
-    Bitboard frozen = pos.freeze_move_squares();
+    Bitboard frozen = pos.freeze_squares();
 
     const bool allowFriendlyCaptures = pos.self_capture()
                                     && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS);
@@ -594,7 +594,7 @@ namespace {
     const Variant* var = pos.variant();
     const PieceType royal = pos.royal_piece_type();
     ExtMove* cur = baseEnd;
-    const Bitboard baseFrozen = pos.freeze_move_squares();
+    const Bitboard baseFrozen = pos.freeze_squares();
     const Bitboard allPieces = pos.pieces();
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS
@@ -631,8 +631,8 @@ namespace {
 
             if (potion == Variant::POTION_FREEZE)
             {
-                // New freeze zones apply after the move, so only existing frozen squares block it.
-                Bitboard frozen = baseFrozen;
+                // Freeze only restricts moves, so reuse the base list and filter by frozen squares.
+                Bitboard frozen = baseFrozen | pos.freeze_zone_from_square(gate);
                 ExtMove* write = cur;
                 for (ExtMove* it = baseStart; it != baseEnd; ++it)
                 {

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -518,7 +518,7 @@ namespace {
                 moveList = generate_drops<Us, Type>(pos, moveList, pop_lsb(ps), target & ~pos.pieces(~Us));
 
         // Castling with non-king piece
-        if (!pos.count(Us, royal) && Type != CAPTURES && pos.can_castle(Us & ANY_CASTLING))
+        if (!pos.count(Us, royal) && Type != CAPTURES && !pos.checkers() && pos.can_castle(Us & ANY_CASTLING))
         {
             Square from = pos.castling_king_square(Us);
             for(CastlingRights cr : { Us & KING_SIDE, Us & QUEEN_SIDE } )
@@ -576,7 +576,7 @@ namespace {
         if (pos.pass(Us))
             *moveList++ = make<SPECIAL>(ksq, ksq);
 
-        if ((Type == QUIETS || Type == NON_EVASIONS) && pos.can_castle(Us & ANY_CASTLING))
+        if ((Type == QUIETS || Type == NON_EVASIONS) && !pos.checkers() && pos.can_castle(Us & ANY_CASTLING))
             for (CastlingRights cr : { Us & KING_SIDE, Us & QUEEN_SIDE } )
                 if (!pos.castling_impeded(cr) && pos.can_castle(cr))
                     moveList = make_move_and_gating<CASTLING>(pos, moveList, Us,ksq, pos.castling_rook_square(cr));

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -226,7 +226,7 @@ namespace {
     const Bitboard doubleStepRegion = pos.double_step_region(Us);
     const Bitboard tripleStepRegion = pos.triple_step_region(Us);
 
-    const Bitboard frozen     = pos.frozen_squares(Us);
+    const Bitboard frozen     = pos.freeze_squares();
     const Bitboard pawns      = pos.pieces(Us, PAWN) & ~frozen;
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
     const Bitboard friendlyCapturable = pos.pieces(Us) & ~pos.pieces(Us, royal);
@@ -375,7 +375,7 @@ namespace {
     assert(Pt != KING && Pt != PAWN);
 
     Bitboard bb = pos.pieces(Us, Pt);
-    Bitboard frozen = pos.frozen_squares(Us);
+    Bitboard frozen = pos.freeze_squares();
 
     const bool allowFriendlyCaptures = pos.self_capture()
                                     && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS);
@@ -594,8 +594,7 @@ namespace {
     const Variant* var = pos.variant();
     const PieceType royal = pos.royal_piece_type();
     ExtMove* cur = baseEnd;
-    const Bitboard baseFrozen = pos.frozen_squares(Us);
-    const Bitboard enemyFrozen = pos.frozen_squares(~Us);
+    const Bitboard baseFrozen = pos.freeze_squares();
     const Bitboard allPieces = pos.pieces();
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS
@@ -788,7 +787,7 @@ namespace {
             {
                 std::fill_n(freezeThreatScores, SQUARE_NB, 0);
 
-                const Bitboard frozen = enemyFrozen;
+                const Bitboard frozen = baseFrozen;
                 Bitboard attackers = pos.pieces(~Us) & ~frozen;
                 const Bitboard occ = pos.pieces();
                 const Bitboard ours = pos.pieces(Us);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -492,7 +492,6 @@ namespace {
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
     Bitboard target;
     Bitboard captureTarget = Type == EVASIONS ? ~pos.pieces(Us) : Bitboard(0);
-    Bitboard jumpForbidden = pos.spell_jump_removed();
 
     // Skip generating non-king moves when in double check
     if (Type != EVASIONS || !more_than_one(pos.checkers() & ~pos.non_sliding_riders()))
@@ -514,12 +513,7 @@ namespace {
 
         // Remove inaccessible squares (outside board + wall squares)
         target &= pos.board_bb();
-        if (jumpForbidden)
-            target &= ~jumpForbidden;
-
         captureTarget = target;
-        if (jumpForbidden)
-            captureTarget &= ~jumpForbidden;
         if (pos.self_capture() && (Type == NON_EVASIONS || Type == CAPTURES))
             captureTarget |= pos.pieces(Us) & ~pos.pieces(Us, royal);
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -660,8 +660,8 @@ namespace {
 
             if (potion == Variant::POTION_FREEZE)
             {
-                // Pieces already inside the new freeze block zone cannot be moved on the casting ply.
-                const Bitboard newBlockZone = pos.freeze_block_zone_from_square(gate);
+                // Pieces already inside the new freeze zone cannot be moved on the casting ply.
+                const Bitboard newBlockZoneFull = pos.freeze_zone_from_square(gate);
                 const Bitboard frozen = baseFrozen;
                 ExtMove* write = cur;
                 for (ExtMove* it = freezeStart; it != freezeEnd; ++it)
@@ -676,7 +676,7 @@ namespace {
                     if (mt != NORMAL && mt != CASTLING)
                         continue;
 
-                    if (newBlockZone & from_sq(base))
+                    if (newBlockZoneFull & from_sq(base))
                         continue;
                     if (frozen & from_sq(base))
                         continue;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -958,15 +958,43 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 
   ExtMove* cur = moveList;
 
-  moveList = pos.checkers() ? generate<EVASIONS    >(pos, moveList)
-                            : generate<NON_EVASIONS>(pos, moveList);
-  while (cur != moveList)
+  ExtMove* end = pos.checkers() ? generate<EVASIONS    >(pos, moveList)
+                                : generate<NON_EVASIONS>(pos, moveList);
+  while (cur != end)
       if (!pos.legal(*cur) || pos.virtual_drop(*cur))
-          *cur = (--moveList)->move;
+          *cur = (--end)->move;
       else
           ++cur;
 
-  return moveList;
+  // In check, some potion moves only become evasions because of the gate effect.
+  // Generate extra potion moves from the full non-evasion base list and filter by legality.
+  if (pos.checkers() && pos.potions_enabled())
+  {
+      static thread_local ExtMove baseMoves[MAX_MOVES];
+      ExtMove* baseEnd = generate_base(NON_EVASIONS, pos, baseMoves);
+      ExtMove* potionEnd = generate_potions(NON_EVASIONS, pos, baseMoves, baseEnd);
+
+      for (ExtMove* it = baseEnd; it != potionEnd; ++it)
+      {
+          Move m = it->move;
+          if (!pos.legal(m) || pos.virtual_drop(m))
+              continue;
+
+          bool exists = false;
+          for (ExtMove* scan = moveList; scan != end; ++scan)
+              if (scan->move == m)
+              {
+                  exists = true;
+                  break;
+              }
+          if (exists)
+              continue;
+
+          *end++ = m;
+      }
+  }
+
+  return end;
 }
 
 } // namespace Stockfish

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -42,6 +42,64 @@ namespace {
     }
   };
 
+  struct GateScore {
+    Square gate;
+    int score;
+  };
+
+  constexpr Direction RookDirections[] = {NORTH, SOUTH, EAST, WEST};
+  constexpr Direction BishopDirections[] = {NORTH_EAST, SOUTH_EAST, SOUTH_WEST, NORTH_WEST};
+  constexpr int PotionKingBonus = 10000;
+  constexpr int MaxFreezePotionGates = 8;
+  constexpr int MaxJumpPotionGates = 6;
+
+  void add_jump_gate_scores(const Position& pos, Color us, PieceType pt,
+                            const Direction* dirs, int dirCount, int scores[SQUARE_NB]) {
+    Bitboard sliders = pos.pieces(us, pt);
+    const Bitboard board = pos.board_bb();
+    const Bitboard occ = pos.pieces();
+
+    while (sliders)
+    {
+        Square s = pop_lsb(sliders);
+        for (int i = 0; i < dirCount; ++i)
+        {
+            Direction d = dirs[i];
+            Square cur = s;
+            while (true)
+            {
+                cur += d;
+                if (!is_ok(cur) || !(board & square_bb(cur)))
+                    break;
+                if (occ & square_bb(cur))
+                {
+                    Square blocker = cur;
+                    cur += d;
+                    while (true)
+                    {
+                        if (!is_ok(cur) || !(board & square_bb(cur)))
+                            break;
+                        if (occ & square_bb(cur))
+                        {
+                            Piece target = pos.piece_on(cur);
+                            if (color_of(target) == ~us)
+                            {
+                                int bonus = int(CapturePieceValue[MG][target]);
+                                if (type_of(target) == pos.king_type())
+                                    bonus += PotionKingBonus;
+                                scores[blocker] += bonus;
+                            }
+                            break;
+                        }
+                        cur += d;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+  }
+
   template<MoveType T>
   ExtMove* make_move_and_gating(const Position& pos, ExtMove* moveList, Color us, Square from, Square to, PieceType pt = NO_PIECE_TYPE) {
 
@@ -541,6 +599,9 @@ namespace {
     bool baseMovesSorted = false;
     Move baseMoves[MAX_MOVES];
     int baseCount = 0;
+    constexpr bool LimitPotionGates = Type == QUIETS;
+    int jumpGateScores[SQUARE_NB];
+    bool jumpScoresReady = false;
 
     for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
     {
@@ -558,12 +619,10 @@ namespace {
         if (potion == Variant::POTION_JUMP)
             candidates &= allPieces;
 
-        while (candidates)
-        {
-            Square gate = pop_lsb(candidates);
+        auto generate_for_gate = [&](Square gate) {
 
             if (potion == Variant::POTION_JUMP && !(allPieces & gate))
-                continue;
+                return;
 
             if (potion == Variant::POTION_FREEZE)
             {
@@ -595,7 +654,7 @@ namespace {
                 }
 
                 cur = write;
-                continue;
+                return;
             }
 
             Bitboard jumpRemoved = square_bb(gate);
@@ -625,7 +684,7 @@ namespace {
 
             cur = write;
             if (!allowNonKing)
-                continue;
+                return;
 
             if (!baseMovesSorted)
             {
@@ -693,6 +752,57 @@ namespace {
             }
 
             cur = write;
+        };
+
+        if constexpr (LimitPotionGates)
+        {
+            GateScore gateScores[SQUARE_NB];
+            int gateCount = 0;
+
+            if (potion == Variant::POTION_JUMP && !jumpScoresReady)
+            {
+                std::fill_n(jumpGateScores, SQUARE_NB, 0);
+                add_jump_gate_scores(pos, Us, ROOK, RookDirections, 4, jumpGateScores);
+                add_jump_gate_scores(pos, Us, BISHOP, BishopDirections, 4, jumpGateScores);
+                add_jump_gate_scores(pos, Us, QUEEN, RookDirections, 4, jumpGateScores);
+                add_jump_gate_scores(pos, Us, QUEEN, BishopDirections, 4, jumpGateScores);
+                jumpScoresReady = true;
+            }
+
+            while (candidates)
+            {
+                Square gate = pop_lsb(candidates);
+                int score = 0;
+                if (potion == Variant::POTION_FREEZE)
+                {
+                    Bitboard zone = pos.freeze_zone_from_square(gate);
+                    Bitboard enemies = zone & pos.pieces(~Us);
+                    while (enemies)
+                        score += int(CapturePieceValue[MG][pos.piece_on(pop_lsb(enemies))]);
+                    PieceType kingType = pos.king_type();
+                    if (kingType != NO_PIECE_TYPE && (zone & pos.pieces(~Us, kingType)))
+                        score += PotionKingBonus;
+                }
+                else
+                    score = jumpGateScores[gate];
+                gateScores[gateCount++] = {gate, score};
+            }
+
+            int gateLimit = potion == Variant::POTION_FREEZE ? MaxFreezePotionGates : MaxJumpPotionGates;
+            if (gateCount > gateLimit)
+            {
+                std::partial_sort(gateScores, gateScores + gateLimit, gateScores + gateCount,
+                                  [](const GateScore& a, const GateScore& b) { return a.score > b.score; });
+                gateCount = gateLimit;
+            }
+
+            for (int i = 0; i < gateCount; ++i)
+                generate_for_gate(gateScores[i].gate);
+        }
+        else
+        {
+            while (candidates)
+                generate_for_gate(pop_lsb(candidates));
         }
     }
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -977,6 +977,10 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
       for (ExtMove* it = baseEnd; it != potionEnd; ++it)
       {
           Move m = it->move;
+          if (type_of(m) == CASTLING)
+              continue;
+          if (!pos.pseudo_legal(m))
+              continue;
           if (!pos.legal(m) || pos.virtual_drop(m))
               continue;
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -602,7 +602,12 @@ namespace {
     bool baseMovesSorted = false;
     Move baseMoves[MAX_MOVES];
     int baseCount = 0;
-    constexpr bool LimitPotionGates = Type == QUIETS;
+    const bool urgentPotionDefense = Type == QUIETS
+                                  && pos.allow_self_check()
+                                  && ksq != SQ_NONE
+                                  && pos.attackers_to(ksq, ~Us);
+    const bool enemyFreezeActive = pos.potion_zone(~Us, Variant::POTION_FREEZE);
+    const bool limitPotionGates = Type == QUIETS && !urgentPotionDefense && !enemyFreezeActive;
     int jumpGateScores[SQUARE_NB];
     bool jumpScoresReady = false;
     int freezeThreatScores[SQUARE_NB];
@@ -769,7 +774,7 @@ namespace {
             cur = write;
         };
 
-        if constexpr (LimitPotionGates)
+        if (limitPotionGates)
         {
             GateScore gateScores[SQUARE_NB];
             int gateCount = 0;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -839,6 +839,62 @@ ExtMove* generate(const Position& pos, ExtMove* moveList) {
                      : generate_all<BLACK, Type>(pos, moveList);
 }
 
+ExtMove* generate_base(GenType Type, const Position& pos, ExtMove* moveList) {
+
+  assert(Type != LEGAL);
+  Color us = pos.side_to_move();
+
+  switch (Type)
+  {
+  case CAPTURES:
+      return us == WHITE ? generate_all_impl<WHITE, CAPTURES>(pos, moveList)
+                         : generate_all_impl<BLACK, CAPTURES>(pos, moveList);
+  case QUIETS:
+      return us == WHITE ? generate_all_impl<WHITE, QUIETS>(pos, moveList)
+                         : generate_all_impl<BLACK, QUIETS>(pos, moveList);
+  case QUIET_CHECKS:
+      return us == WHITE ? generate_all_impl<WHITE, QUIET_CHECKS>(pos, moveList)
+                         : generate_all_impl<BLACK, QUIET_CHECKS>(pos, moveList);
+  case EVASIONS:
+      return us == WHITE ? generate_all_impl<WHITE, EVASIONS>(pos, moveList)
+                         : generate_all_impl<BLACK, EVASIONS>(pos, moveList);
+  case NON_EVASIONS:
+      return us == WHITE ? generate_all_impl<WHITE, NON_EVASIONS>(pos, moveList)
+                         : generate_all_impl<BLACK, NON_EVASIONS>(pos, moveList);
+  default:
+      assert(false);
+      return moveList;
+  }
+}
+
+ExtMove* generate_potions(GenType Type, const Position& pos, ExtMove* baseStart, ExtMove* baseEnd) {
+
+  assert(Type != LEGAL);
+  Color us = pos.side_to_move();
+
+  switch (Type)
+  {
+  case CAPTURES:
+      return us == WHITE ? generate_potion_moves<WHITE, CAPTURES>(pos, baseStart, baseEnd)
+                         : generate_potion_moves<BLACK, CAPTURES>(pos, baseStart, baseEnd);
+  case QUIETS:
+      return us == WHITE ? generate_potion_moves<WHITE, QUIETS>(pos, baseStart, baseEnd)
+                         : generate_potion_moves<BLACK, QUIETS>(pos, baseStart, baseEnd);
+  case QUIET_CHECKS:
+      return us == WHITE ? generate_potion_moves<WHITE, QUIET_CHECKS>(pos, baseStart, baseEnd)
+                         : generate_potion_moves<BLACK, QUIET_CHECKS>(pos, baseStart, baseEnd);
+  case EVASIONS:
+      return us == WHITE ? generate_potion_moves<WHITE, EVASIONS>(pos, baseStart, baseEnd)
+                         : generate_potion_moves<BLACK, EVASIONS>(pos, baseStart, baseEnd);
+  case NON_EVASIONS:
+      return us == WHITE ? generate_potion_moves<WHITE, NON_EVASIONS>(pos, baseStart, baseEnd)
+                         : generate_potion_moves<BLACK, NON_EVASIONS>(pos, baseStart, baseEnd);
+  default:
+      assert(false);
+      return baseEnd;
+  }
+}
+
 // Explicit template instantiations
 template ExtMove* generate<CAPTURES>(const Position&, ExtMove*);
 template ExtMove* generate<QUIETS>(const Position&, ExtMove*);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -50,7 +50,8 @@ namespace {
   constexpr Direction RookDirections[] = {NORTH, SOUTH, EAST, WEST};
   constexpr Direction BishopDirections[] = {NORTH_EAST, SOUTH_EAST, SOUTH_WEST, NORTH_WEST};
   constexpr int PotionKingBonus = 10000;
-  constexpr int MaxFreezePotionGates = 8;
+  constexpr int PotionKingRingBonus = 50000;
+  constexpr int MaxFreezePotionGates = 12;
   constexpr int MaxJumpPotionGates = 6;
 
   void add_jump_gate_scores(const Position& pos, Color us, PieceType pt,
@@ -235,8 +236,7 @@ namespace {
     Bitboard capturable = pos.board_bb(Us, PAWN)
                         & (allowFriendlyCaptures ? (pos.pieces(Them) | friendlyCapturable)
                                                  :  pos.pieces(Them));
-    if (jumpMask)
-        capturable &= ~jumpMask;
+    // Captures onto jump squares are legal; keep them in the capture set.
 
     target = Type == EVASIONS ? target : AllSquares;
 
@@ -394,6 +394,16 @@ namespace {
         Bitboard attacks = pos.attacks_from(Us, Pt, from);
         Bitboard quiets = pos.moves_from(Us, Pt, from);
         Bitboard captureSquares = (attacks & pos.pieces()) & captureTarget;
+        if (pos.potions_enabled())
+        {
+            const Bitboard jumpMask = pos.jump_squares(Us);
+            const Bitboard jumpCapturable = jumpMask & pos.pieces();
+            if (jumpCapturable)
+            {
+                Bitboard solidAttacks = attacks_bb(Us, Pt, from, pos.pieces());
+                captureSquares |= solidAttacks & jumpCapturable & captureTarget;
+            }
+        }
         Bitboard quietSquares   = (quiets & ~pos.pieces()) & target;
         Bitboard b = captureSquares | quietSquares;
         Bitboard b1 = b;
@@ -601,6 +611,7 @@ namespace {
     const Bitboard baseFrozen = pos.freeze_squares(Us);
     const Bitboard allPieces = pos.pieces();
     const Square ksq = pos.count(Us, royal) ? pos.square(Us, royal) : SQ_NONE;
+    const Square enemyKsq = pos.count(~Us, royal) ? pos.square(~Us, royal) : SQ_NONE;
     const bool allowNonKing = Type != EVASIONS
                            || !more_than_one(pos.checkers() & ~pos.non_sliding_riders());
     bool baseMovesSorted = false;
@@ -786,6 +797,9 @@ namespace {
         {
             GateScore gateScores[SQUARE_NB];
             int gateCount = 0;
+            int ringGateCount = 0;
+            const Bitboard enemyRing = enemyKsq != SQ_NONE ? (attacks_bb<KING>(enemyKsq) | square_bb(enemyKsq))
+                                                           : Bitboard(0);
 
             if (potion == Variant::POTION_JUMP && !jumpScoresReady)
             {
@@ -851,6 +865,11 @@ namespace {
                     }
                     if (royal != NO_PIECE_TYPE && (zone & pos.pieces(~Us, royal)))
                         score += PotionKingBonus;
+                    if (enemyKsq != SQ_NONE && (zone & enemyRing))
+                    {
+                        score += PotionKingRingBonus;
+                        ++ringGateCount;
+                    }
                 }
                 else
                     score = jumpGateScores[gate];
@@ -858,6 +877,8 @@ namespace {
             }
 
             int gateLimit = potion == Variant::POTION_FREEZE ? MaxFreezePotionGates : MaxJumpPotionGates;
+            if (potion == Variant::POTION_FREEZE && ringGateCount > gateLimit)
+                gateLimit = ringGateCount;
             if (gateCount > gateLimit)
             {
                 std::partial_sort(gateScores, gateScores + gateLimit, gateScores + gateCount,

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -872,6 +872,9 @@ namespace {
 ///
 /// Returns a pointer to the end of the move list.
 
+ExtMove* generate_base(GenType Type, const Position& pos, ExtMove* moveList);
+ExtMove* generate_potions(GenType Type, const Position& pos, ExtMove* baseStart, ExtMove* baseEnd);
+
 template<GenType Type>
 ExtMove* generate(const Position& pos, ExtMove* moveList) {
 
@@ -880,8 +883,43 @@ ExtMove* generate(const Position& pos, ExtMove* moveList) {
 
   Color us = pos.side_to_move();
 
-  return us == WHITE ? generate_all<WHITE, Type>(pos, moveList)
-                     : generate_all<BLACK, Type>(pos, moveList);
+  ExtMove* end = us == WHITE ? generate_all<WHITE, Type>(pos, moveList)
+                             : generate_all<BLACK, Type>(pos, moveList);
+
+  // In check, some potion moves only become evasions because of the gate effect.
+  // Generate extra potion moves from the full non-evasion base list and filter by legality.
+  if constexpr (Type == EVASIONS)
+      if (pos.potions_enabled())
+      {
+          static thread_local ExtMove baseMoves[MAX_MOVES];
+          ExtMove* baseEnd = generate_base(NON_EVASIONS, pos, baseMoves);
+          ExtMove* potionEnd = generate_potions(NON_EVASIONS, pos, baseMoves, baseEnd);
+
+          for (ExtMove* it = baseEnd; it != potionEnd; ++it)
+          {
+              Move m = it->move;
+              if (type_of(m) == CASTLING)
+                  continue;
+              if (!pos.pseudo_legal(m))
+                  continue;
+              if (!pos.legal(m) || pos.virtual_drop(m))
+                  continue;
+
+              bool exists = false;
+              for (ExtMove* scan = moveList; scan != end; ++scan)
+                  if (scan->move == m)
+                  {
+                      exists = true;
+                      break;
+                  }
+              if (exists)
+                  continue;
+
+              *end++ = m;
+          }
+      }
+
+  return end;
 }
 
 ExtMove* generate_base(GenType Type, const Position& pos, ExtMove* moveList) {

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -55,6 +55,9 @@ inline bool operator<(const ExtMove& f, const ExtMove& s) {
 template<GenType>
 ExtMove* generate(const Position& pos, ExtMove* moveList);
 
+ExtMove* generate_base(GenType Type, const Position& pos, ExtMove* moveList);
+ExtMove* generate_potions(GenType Type, const Position& pos, ExtMove* baseStart, ExtMove* baseEnd);
+
 constexpr size_t moveListSize = sizeof(ExtMove) * MAX_MOVES;
 
 /// The MoveList struct is a simple wrapper around generate(). It sometimes comes

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -35,7 +35,7 @@ namespace {
     MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, POTION_INIT, POTION, BAD_CAPTURE,
     EVASION_TT, EVASION_INIT, EVASION,
     PROBCUT_TT, PROBCUT_INIT, PROBCUT,
-    QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
+    QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QPOTION_INIT, QPOTION, QCHECK_INIT, QCHECK
   };
 
   // partial_insertion_sort() sorts moves in descending order up to and including
@@ -59,6 +59,7 @@ namespace {
   constexpr int PotionGateHigh = 6000;
   constexpr int PotionPenaltyMid = PotionPenalty / 2;
   constexpr int PotionPenaltyHigh = PotionPenalty / 8;
+  constexpr int PotionQsearchMinScore = PotionGateMid;
 } // namespace
 
 
@@ -385,6 +386,46 @@ top:
       if (depth != DEPTH_QS_CHECKS)
           return MOVE_NONE;
 
+      ++stage;
+      [[fallthrough]];
+
+  case QPOTION_INIT: {
+      const Color us = pos.side_to_move();
+      bool canCastPotion = false;
+      if (pos.potions_enabled() && !(pos.must_capture() && pos.has_capture()))
+          for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+          {
+              auto potion = static_cast<Variant::PotionType>(pt);
+              if (pos.can_cast_potion(us, potion))
+              {
+                  canCastPotion = true;
+                  break;
+              }
+          }
+
+      if (!canCastPotion)
+      {
+          stage = QCHECK_INIT;
+          goto top;
+      }
+
+      ExtMove* baseEnd = generate_base(QUIETS, pos, moves);
+      cur = baseEnd;
+      endMoves = generate_potions(QUIETS, pos, moves, baseEnd);
+      if (cur == endMoves)
+      {
+          stage = QCHECK_INIT;
+          goto top;
+      }
+
+      partial_insertion_sort(cur, endMoves, PotionQsearchMinScore);
+      ++stage;
+      [[fallthrough]];
+  }
+
+  case QPOTION:
+      if (select<Next>([&](){ return cur->value >= PotionQsearchMinScore; }))
+          return *(cur - 1);
       ++stage;
       [[fallthrough]];
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -326,12 +326,13 @@ top:
           skipQuiets
           && pos.potions_enabled()
           && pos.allow_self_check()
-          && pos.potion_zone(~us, Variant::POTION_FREEZE);
+          && (pos.potion_zone(~us, Variant::POTION_FREEZE)
+              || pos.can_cast_potion(us, Variant::POTION_FREEZE)
+              || pos.can_cast_potion(us, Variant::POTION_JUMP));
 
       if (   (skipQuiets && !allowPotionsWhenSkipping)
           || (pos.must_capture() && pos.has_capture())
-          || !pos.potions_enabled()
-          || quietStart == quietEnd)
+          || !pos.potions_enabled())
       {
           cur = moves;
           endMoves = endBadCaptures;
@@ -339,8 +340,38 @@ top:
           goto top;
       }
 
-      cur = quietEnd;
-      endMoves = generate_potions(QUIETS, pos, quietStart, quietEnd);
+      if (skipQuiets && allowPotionsWhenSkipping)
+      {
+          static thread_local ExtMove baseMoves[MAX_MOVES];
+          ExtMove* baseEnd = generate_base(QUIETS, pos, baseMoves);
+          ExtMove* potionEnd = generate_potions(QUIETS, pos, baseMoves, baseEnd);
+
+          if (potionEnd == baseEnd)
+          {
+              cur = moves;
+              endMoves = endBadCaptures;
+              stage = BAD_CAPTURE;
+              goto top;
+          }
+
+          const ptrdiff_t count = potionEnd - baseEnd;
+          std::copy(baseEnd, potionEnd, moves);
+          cur = moves;
+          endMoves = moves + count;
+      }
+      else
+      {
+          if (quietStart == quietEnd)
+          {
+              cur = moves;
+              endMoves = endBadCaptures;
+              stage = BAD_CAPTURE;
+              goto top;
+          }
+
+          cur = quietEnd;
+          endMoves = generate_potions(QUIETS, pos, quietStart, quietEnd);
+      }
 
       score<QUIETS>();
       partial_insertion_sort(cur, endMoves, -3000 * depth);

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -127,7 +127,8 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   assert(d > 0);
 
-  stage = (pos.checkers() ? EVASION_TT : MAIN_TT) +
+  bool needsEvasion = pos.checkers() && !pos.allow_self_check();
+  stage = (needsEvasion ? EVASION_TT : MAIN_TT) +
           !(ttm && pos.pseudo_legal(ttm));
 }
 
@@ -138,9 +139,10 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 
   assert(d <= 0);
 
-  stage = (pos.checkers() ? EVASION_TT : QSEARCH_TT) +
+  bool needsEvasion = pos.checkers() && !pos.allow_self_check();
+  stage = (needsEvasion ? EVASION_TT : QSEARCH_TT) +
           !(   ttm
-            && (pos.checkers() || depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
+            && (needsEvasion || depth > DEPTH_QS_RECAPTURES || to_sq(ttm) == recaptureSquare)
             && pos.pseudo_legal(ttm));
 }
 
@@ -149,7 +151,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 MovePicker::MovePicker(const Position& p, Move ttm, Value th, const GateHistory* dh, const CapturePieceToHistory* cph)
            : pos(p), gateHistory(dh), captureHistory(cph), ttMove(ttm), quietStart(moves), quietEnd(moves), threshold(th) {
 
-  assert(!pos.checkers());
+  assert(!pos.checkers() || pos.allow_self_check());
 
   stage = PROBCUT_TT + !(ttm && pos.capture(ttm)
                              && pos.pseudo_legal(ttm)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -54,6 +54,11 @@ namespace {
   }
 
   constexpr int PotionPenalty = 1 << 28;
+  constexpr int PotionGateScale = 4;
+  constexpr int PotionGateMid = 1200;
+  constexpr int PotionGateHigh = 6000;
+  constexpr int PotionPenaltyMid = PotionPenalty / 2;
+  constexpr int PotionPenaltyHigh = PotionPenalty / 8;
 } // namespace
 
 
@@ -161,6 +166,9 @@ void MovePicker::score() {
 
   for (auto& m : *this)
   {
+      const bool potionMove = is_potion_move(m);
+      const int gateBonus = potionMove ? m.value : 0;
+
       if constexpr (Type == CAPTURES)
           m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
                    + (*gateHistory)[pos.side_to_move()][gating_square(m)]       
@@ -186,9 +194,21 @@ void MovePicker::score() {
                        - (1 << 28);
       }
 
-      if constexpr (Type == CAPTURES || Type == QUIETS)
-          if (is_potion_move(m))
-              m.value -= PotionPenalty;
+      if constexpr (Type == CAPTURES)
+      {
+          if (potionMove)
+              m.value += gateBonus;
+      }
+      else if constexpr (Type == QUIETS)
+      {
+          if (potionMove)
+          {
+              m.value += gateBonus * PotionGateScale;
+              m.value -= gateBonus >= PotionGateHigh ? PotionPenaltyHigh
+                       : gateBonus >= PotionGateMid ? PotionPenaltyMid
+                                                    : PotionPenalty;
+          }
+      }
   }
 }
 
@@ -297,7 +317,7 @@ top:
       ++stage;
       [[fallthrough]];
 
-  case POTION_INIT:
+  case POTION_INIT: {
       if (   skipQuiets
           || (pos.must_capture() && pos.has_capture())
           || !pos.potions_enabled()
@@ -317,6 +337,7 @@ top:
 
       ++stage;
       [[fallthrough]];
+  }
 
   case POTION:
       if (select<Next>([&](){return true;}))

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -32,7 +32,7 @@ int history_slot(Piece pc) {
 namespace {
 
   enum Stages {
-    MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, BAD_CAPTURE,
+    MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, POTION_INIT, POTION, BAD_CAPTURE,
     EVASION_TT, EVASION_INIT, EVASION,
     PROBCUT_TT, PROBCUT_INIT, PROBCUT,
     QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
@@ -118,7 +118,7 @@ bool MovePicker::is_potion_move(Move m) const {
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const GateHistory* dh, const LowPlyHistory* lp,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, const Move* killers, int pl)
            : pos(p), mainHistory(mh), gateHistory(dh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
-             ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, depth(d), ply(pl) {
+             ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, quietStart(moves), quietEnd(moves), depth(d), ply(pl) {
 
   assert(d > 0);
 
@@ -129,7 +129,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for quiescence search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const GateHistory* dh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Square rs)
-           : pos(p), mainHistory(mh), gateHistory(dh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), recaptureSquare(rs), depth(d) {
+           : pos(p), mainHistory(mh), gateHistory(dh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), quietStart(moves), quietEnd(moves), recaptureSquare(rs), depth(d) {
 
   assert(d <= 0);
 
@@ -142,7 +142,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
 /// than or equal to the given threshold.
 MovePicker::MovePicker(const Position& p, Move ttm, Value th, const GateHistory* dh, const CapturePieceToHistory* cph)
-           : pos(p), gateHistory(dh), captureHistory(cph), ttMove(ttm), threshold(th) {
+           : pos(p), gateHistory(dh), captureHistory(cph), ttMove(ttm), quietStart(moves), quietEnd(moves), threshold(th) {
 
   assert(!pos.checkers());
 
@@ -273,12 +273,16 @@ top:
   case QUIET_INIT:
       if (!skipQuiets && !(pos.must_capture() && pos.has_capture()))
       {
-          cur = endBadCaptures;
-          endMoves = generate<QUIETS>(pos, cur);
+          quietStart = endBadCaptures;
+          quietEnd = generate_base(QUIETS, pos, quietStart);
+          cur = quietStart;
+          endMoves = quietEnd;
 
           score<QUIETS>();
           partial_insertion_sort(cur, endMoves, -3000 * depth);
       }
+      else
+          quietStart = quietEnd = endBadCaptures;
 
       ++stage;
       [[fallthrough]];
@@ -288,6 +292,34 @@ top:
           && select<Next>([&](){return   *cur != refutations[0].move
                                       && *cur != refutations[1].move
                                       && *cur != refutations[2].move;}))
+          return *(cur - 1);
+
+      ++stage;
+      [[fallthrough]];
+
+  case POTION_INIT:
+      if (   skipQuiets
+          || (pos.must_capture() && pos.has_capture())
+          || !pos.potions_enabled()
+          || quietStart == quietEnd)
+      {
+          cur = moves;
+          endMoves = endBadCaptures;
+          stage = BAD_CAPTURE;
+          goto top;
+      }
+
+      cur = quietEnd;
+      endMoves = generate_potions(QUIETS, pos, quietStart, quietEnd);
+
+      score<QUIETS>();
+      partial_insertion_sort(cur, endMoves, -3000 * depth);
+
+      ++stage;
+      [[fallthrough]];
+
+  case POTION:
+      if (select<Next>([&](){return true;}))
           return *(cur - 1);
 
       // Prepare the pointers to loop over the bad captures

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -40,7 +40,7 @@ namespace {
 
   // partial_insertion_sort() sorts moves in descending order up to and including
   // a given limit. The order of moves smaller than the limit is left unspecified.
-  void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
+  void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {        
 
     for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
         if (p->value >= limit)
@@ -53,6 +53,7 @@ namespace {
         }
   }
 
+  constexpr int PotionPenalty = 1 << 28;
 } // namespace
 
 
@@ -89,6 +90,19 @@ bool MovePicker::is_useless_potion(Move m) const {
 
       break;
   }
+
+  return false;
+}
+
+bool MovePicker::is_potion_move(Move m) const {
+
+  if (!pos.potions_enabled() || !is_gating(m))
+      return false;
+
+  PieceType gatingPiece = gating_type(m);
+  for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+      if (pos.potion_piece(static_cast<Variant::PotionType>(idx)) == gatingPiece)
+          return true;
 
   return false;
 }
@@ -146,14 +160,15 @@ void MovePicker::score() {
   static_assert(Type == CAPTURES || Type == QUIETS || Type == EVASIONS, "Wrong type");
 
   for (auto& m : *this)
+  {
       if constexpr (Type == CAPTURES)
           m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
-                   + (*gateHistory)[pos.side_to_move()][gating_square(m)]
+                   + (*gateHistory)[pos.side_to_move()][gating_square(m)]       
                    + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if constexpr (Type == QUIETS)
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
-                   +     (*gateHistory)[pos.side_to_move()][gating_square(m)]
+                   +     (*gateHistory)[pos.side_to_move()][gating_square(m)]   
                    + 2 * (*continuationHistory[0])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[1])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[3])[history_slot(pos.moved_piece(m))][to_sq(m)]
@@ -166,10 +181,15 @@ void MovePicker::score() {
               m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
                        - Value(type_of(pos.moved_piece(m)));
           else
-              m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
+              m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]     
                        + 2 * (*continuationHistory[0])[history_slot(pos.moved_piece(m))][to_sq(m)]
                        - (1 << 28);
       }
+
+      if constexpr (Type == CAPTURES || Type == QUIETS)
+          if (is_potion_move(m))
+              m.value -= PotionPenalty;
+  }
 }
 
 /// MovePicker::select() returns the next move satisfying a predicate function.

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -35,7 +35,7 @@ namespace {
     MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, POTION_INIT, POTION, BAD_CAPTURE,
     EVASION_TT, EVASION_INIT, EVASION,
     PROBCUT_TT, PROBCUT_INIT, PROBCUT,
-    QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK, QPOTION_INIT, QPOTION
+    QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
   };
 
   // partial_insertion_sort() sorts moves in descending order up to and including
@@ -110,36 +110,6 @@ bool MovePicker::is_potion_move(Move m) const {
           return true;
 
   return false;
-}
-
-bool MovePicker::is_tactical_potion(Move m) const {
-
-  if (!pos.potions_enabled() || !is_gating(m))
-      return false;
-
-  Variant::PotionType potion = Variant::POTION_TYPE_NB;
-  PieceType gatingPiece = gating_type(m);
-  for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
-      if (pos.potion_piece(static_cast<Variant::PotionType>(idx)) == gatingPiece)
-      {
-          potion = static_cast<Variant::PotionType>(idx);
-          break;
-      }
-
-  if (potion != Variant::POTION_FREEZE)
-      return false;
-
-  PieceType royal = pos.royal_piece_type();
-  Square enemyRoyal = pos.count(~pos.side_to_move(), royal) ? pos.square(~pos.side_to_move(), royal) : SQ_NONE;
-  Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
-  if (enemyRoyal != SQ_NONE && (zone & square_bb(enemyRoyal)))
-      return true;
-
-  if (!pos.count(pos.side_to_move(), royal))
-      return false;
-
-  Bitboard attackers = pos.attackers_to(pos.square(pos.side_to_move(), royal), ~pos.side_to_move());
-  return attackers && (zone & attackers);
 }
 
 
@@ -417,35 +387,7 @@ top:
       [[fallthrough]];
 
   case QCHECK:
-      if (select<Next>([](){ return true; }))
-          return *(cur - 1);
-      if (!pos.potions_enabled() || depth < DEPTH_QS_CHECKS)
-          return MOVE_NONE;
-      stage = QPOTION_INIT;
-      goto top;
-
-  case QPOTION_INIT: {
-      if (!pos.potions_enabled() || !pos.can_cast_potion(pos.side_to_move(), Variant::POTION_FREEZE))
-          return MOVE_NONE;
-      if (pos.must_capture() && pos.has_capture())
-          return MOVE_NONE;
-
-      quietStart = moves;
-      quietEnd = generate_base(QUIETS, pos, quietStart);
-      cur = quietEnd;
-      endMoves = generate_potions(QUIETS, pos, quietStart, quietEnd);
-
-      score<QUIETS>();
-      partial_insertion_sort(cur, endMoves, -3000 * depth);
-
-      ++stage;
-      [[fallthrough]];
-  }
-
-  case QPOTION:
-      if (select<Next>([&](){ return is_tactical_potion(*cur); }))
-          return *(cur - 1);
-      return MOVE_NONE;
+      return select<Next>([](){ return true; });
   }
 
   assert(false);

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -320,7 +320,14 @@ top:
       [[fallthrough]];
 
   case POTION_INIT: {
-      if (   skipQuiets
+      const Color us = pos.side_to_move();
+      const bool allowPotionsWhenSkipping =
+          skipQuiets
+          && pos.potions_enabled()
+          && pos.allow_self_check()
+          && pos.potion_zone(~us, Variant::POTION_FREEZE);
+
+      if (   (skipQuiets && !allowPotionsWhenSkipping)
           || (pos.must_capture() && pos.has_capture())
           || !pos.potions_enabled()
           || quietStart == quietEnd)

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -35,7 +35,7 @@ namespace {
     MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, POTION_INIT, POTION, BAD_CAPTURE,
     EVASION_TT, EVASION_INIT, EVASION,
     PROBCUT_TT, PROBCUT_INIT, PROBCUT,
-    QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
+    QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK, QPOTION_INIT, QPOTION
   };
 
   // partial_insertion_sort() sorts moves in descending order up to and including
@@ -110,6 +110,36 @@ bool MovePicker::is_potion_move(Move m) const {
           return true;
 
   return false;
+}
+
+bool MovePicker::is_tactical_potion(Move m) const {
+
+  if (!pos.potions_enabled() || !is_gating(m))
+      return false;
+
+  Variant::PotionType potion = Variant::POTION_TYPE_NB;
+  PieceType gatingPiece = gating_type(m);
+  for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+      if (pos.potion_piece(static_cast<Variant::PotionType>(idx)) == gatingPiece)
+      {
+          potion = static_cast<Variant::PotionType>(idx);
+          break;
+      }
+
+  if (potion != Variant::POTION_FREEZE)
+      return false;
+
+  PieceType royal = pos.royal_piece_type();
+  Square enemyRoyal = pos.count(~pos.side_to_move(), royal) ? pos.square(~pos.side_to_move(), royal) : SQ_NONE;
+  Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
+  if (enemyRoyal != SQ_NONE && (zone & square_bb(enemyRoyal)))
+      return true;
+
+  if (!pos.count(pos.side_to_move(), royal))
+      return false;
+
+  Bitboard attackers = pos.attackers_to(pos.square(pos.side_to_move(), royal), ~pos.side_to_move());
+  return attackers && (zone & attackers);
 }
 
 
@@ -387,7 +417,35 @@ top:
       [[fallthrough]];
 
   case QCHECK:
-      return select<Next>([](){ return true; });
+      if (select<Next>([](){ return true; }))
+          return *(cur - 1);
+      if (!pos.potions_enabled() || depth < DEPTH_QS_CHECKS)
+          return MOVE_NONE;
+      stage = QPOTION_INIT;
+      goto top;
+
+  case QPOTION_INIT: {
+      if (!pos.potions_enabled() || !pos.can_cast_potion(pos.side_to_move(), Variant::POTION_FREEZE))
+          return MOVE_NONE;
+      if (pos.must_capture() && pos.has_capture())
+          return MOVE_NONE;
+
+      quietStart = moves;
+      quietEnd = generate_base(QUIETS, pos, quietStart);
+      cur = quietEnd;
+      endMoves = generate_potions(QUIETS, pos, quietStart, quietEnd);
+
+      score<QUIETS>();
+      partial_insertion_sort(cur, endMoves, -3000 * depth);
+
+      ++stage;
+      [[fallthrough]];
+  }
+
+  case QPOTION:
+      if (select<Next>([&](){ return is_tactical_potion(*cur); }))
+          return *(cur - 1);
+      return MOVE_NONE;
   }
 
   assert(false);

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,7 +146,6 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_potion_move(Move m) const;
-  bool is_tactical_potion(Move m) const;
   bool is_useless_potion(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,6 +146,7 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_potion_move(Move m) const;
+  bool is_tactical_potion(Move m) const;
   bool is_useless_potion(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -157,7 +157,7 @@ private:
   const CapturePieceToHistory* captureHistory;
   const PieceToHistory** continuationHistory;
   Move ttMove;
-  ExtMove refutations[3], *cur, *endMoves, *endBadCaptures;
+  ExtMove refutations[3], *cur, *endMoves, *endBadCaptures, *quietStart, *quietEnd;
   int stage;
   Square recaptureSquare;
   Value threshold;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -145,6 +145,7 @@ public:
 private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
+  bool is_potion_move(Move m) const;
   bool is_useless_potion(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -119,7 +119,7 @@ namespace Stockfish::Eval::NNUE {
 
     std::uint32_t hashValue;
     if (!read_header(stream, &hashValue, &netDescription)) return false;
-    if (hashValue != HashValue) return false;
+    if (hashValue != hash_value()) return false;
     if (!Detail::read_parameters(stream, *featureTransformer)) return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
       if (!Detail::read_parameters(stream, *(network[i]))) return false;
@@ -129,7 +129,7 @@ namespace Stockfish::Eval::NNUE {
   // Write network parameters
   bool write_parameters(std::ostream& stream) {
 
-    if (!write_header(stream, HashValue, netDescription)) return false;
+    if (!write_header(stream, hash_value(), netDescription)) return false;
     if (!Detail::write_parameters(stream, *featureTransformer)) return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
       if (!Detail::write_parameters(stream, *(network[i]))) return false;

--- a/src/nnue/evaluate_nnue.h
+++ b/src/nnue/evaluate_nnue.h
@@ -28,8 +28,9 @@
 namespace Stockfish::Eval::NNUE {
 
   // Hash value of evaluation function structure
-  constexpr std::uint32_t HashValue =
-      FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
+  inline std::uint32_t hash_value() {
+    return FeatureTransformer::get_hash_value() ^ Network::get_hash_value();
+  }
 
   // Deleter for automating release of memory area
   template <typename T>

--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -46,6 +46,29 @@ namespace Stockfish::Eval::NNUE::Features {
     return IndexType(handCount + pos.nnue_piece_hand_index(perspective, pc) + pos.nnue_king_square_index(ksq));
   }
 
+  inline IndexType HalfKAv2Variants::make_potion_zone_index(Color perspective, Color potionColor,
+                                                            Variant::PotionType potion, Square s,
+                                                            Square ksq, const Position& pos) {
+    const int potionIndex = static_cast<int>(potion)
+                            + Variant::POTION_TYPE_NB * static_cast<int>(potionColor);
+    return IndexType(orient(perspective, s, pos)
+                     + pos.nnue_potion_zone_index_base()
+                     + potionIndex * (pos.max_file() + 1) * (pos.max_rank() + 1)
+                     + pos.nnue_king_square_index(ksq));
+  }
+
+  inline IndexType HalfKAv2Variants::make_potion_cooldown_index(Color perspective, Color potionColor,
+                                                                Variant::PotionType potion, int bit,
+                                                                Square ksq, const Position& pos) {
+    (void)perspective;
+    const int potionIndex = static_cast<int>(potion)
+                            + Variant::POTION_TYPE_NB * static_cast<int>(potionColor);
+    return IndexType(bit
+                     + pos.nnue_potion_cooldown_index_base()
+                     + potionIndex * POTION_COOLDOWN_BITS
+                     + pos.nnue_king_square_index(ksq));
+  }
+
   // Get a list of indices for active features
   void HalfKAv2Variants::append_active_indices(
     const Position& pos,
@@ -58,6 +81,27 @@ namespace Stockfish::Eval::NNUE::Features {
     {
       Square s = pop_lsb(bb);
       active.push_back(make_index(perspective, s, pos.piece_on(s), oriented_ksq, pos));
+    }
+
+    if (pos.nnue_potion_zone_index_base() >= 0)
+    {
+      for (Color c : {WHITE, BLACK})
+          for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+          {
+              Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+              if (pos.potion_piece(potion) == NO_PIECE_TYPE)
+                  continue;
+              Bitboard zone = pos.potion_zone(c, potion);
+              while (zone)
+              {
+                  Square s = pop_lsb(zone);
+                  active.push_back(make_potion_zone_index(perspective, c, potion, s, oriented_ksq, pos));
+              }
+              unsigned int cooldown = static_cast<unsigned int>(pos.potion_cooldown(c, potion));
+              for (int bit = 0; bit < POTION_COOLDOWN_BITS; ++bit)
+                  if (cooldown & (1u << bit))
+                      active.push_back(make_potion_cooldown_index(perspective, c, potion, bit, oriented_ksq, pos));
+          }
     }
 
     // Indices for pieces in hand
@@ -95,14 +139,74 @@ namespace Stockfish::Eval::NNUE::Features {
       else if (dp.handPiece[i] != NO_PIECE)
         added.push_back(make_index(perspective, dp.handCount[i] - 1, dp.handPiece[i], oriented_ksq, pos));
     }
+
+    if (pos.nnue_potion_zone_index_base() >= 0)
+    {
+      for (Color c : {WHITE, BLACK})
+          for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+          {
+              Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+              if (pos.potion_piece(potion) == NO_PIECE_TYPE)
+                  continue;
+              Bitboard prevZone = st->previous ? st->previous->potionZones[c][pt] : Bitboard(0);
+              Bitboard curZone = st->potionZones[c][pt];
+              Bitboard removedZones = prevZone & ~curZone;
+              Bitboard addedZones = curZone & ~prevZone;
+              while (removedZones)
+                  removed.push_back(make_potion_zone_index(perspective, c, potion, pop_lsb(removedZones), oriented_ksq, pos));
+              while (addedZones)
+                  added.push_back(make_potion_zone_index(perspective, c, potion, pop_lsb(addedZones), oriented_ksq, pos));
+
+              unsigned int prevCooldown = static_cast<unsigned int>(st->previous ? st->previous->potionCooldown[c][pt] : 0);
+              unsigned int curCooldown = static_cast<unsigned int>(st->potionCooldown[c][pt]);
+              unsigned int diff = prevCooldown ^ curCooldown;
+              for (int bit = 0; bit < POTION_COOLDOWN_BITS; ++bit)
+              {
+                  if (!(diff & (1u << bit)))
+                      continue;
+                  if (prevCooldown & (1u << bit))
+                      removed.push_back(make_potion_cooldown_index(perspective, c, potion, bit, oriented_ksq, pos));
+                  else
+                      added.push_back(make_potion_cooldown_index(perspective, c, potion, bit, oriented_ksq, pos));
+              }
+          }
+    }
   }
 
   int HalfKAv2Variants::update_cost(StateInfo* st) {
-    return st->dirtyPiece.dirty_num;
+    int cost = st->dirtyPiece.dirty_num;
+    if (!currentNnueVariant || currentNnueVariant->nnuePotionZoneIndexBase < 0)
+      return cost;
+    for (Color c : {WHITE, BLACK})
+        for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+        {
+            if (currentNnueVariant->potionPiece[pt] == NO_PIECE_TYPE)
+                continue;
+            Bitboard prevZone = st->previous ? st->previous->potionZones[c][pt] : Bitboard(0);
+            Bitboard diffZone = st->potionZones[c][pt] ^ prevZone;
+            cost += popcount(diffZone);
+
+            unsigned int prevCooldown = static_cast<unsigned int>(st->previous ? st->previous->potionCooldown[c][pt] : 0);
+            unsigned int curCooldown = static_cast<unsigned int>(st->potionCooldown[c][pt]);
+            cost += popcount(Bitboard(prevCooldown ^ curCooldown));
+        }
+    return cost;
   }
 
   int HalfKAv2Variants::refresh_cost(const Position& pos) {
-    return pos.count<ALL_PIECES>();
+    int cost = pos.count<ALL_PIECES>();
+    if (pos.nnue_potion_zone_index_base() < 0)
+      return cost;
+    for (Color c : {WHITE, BLACK})
+        for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+        {
+            Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+            if (pos.potion_piece(potion) == NO_PIECE_TYPE)
+                continue;
+            cost += popcount(pos.potion_zone(c, potion));
+            cost += popcount(Bitboard(pos.potion_cooldown(c, potion)));
+        }
+    return cost;
   }
 
   bool HalfKAv2Variants::requires_refresh(StateInfo* st, Color perspective, const Position& pos) {

--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -49,8 +49,9 @@ namespace Stockfish::Eval::NNUE::Features {
   inline IndexType HalfKAv2Variants::make_potion_zone_index(Color perspective, Color potionColor,
                                                             Variant::PotionType potion, Square s,
                                                             Square ksq, const Position& pos) {
+    const int relativeColor = static_cast<int>(potionColor != perspective);
     const int potionIndex = static_cast<int>(potion)
-                            + Variant::POTION_TYPE_NB * static_cast<int>(potionColor);
+                            + Variant::POTION_TYPE_NB * relativeColor;
     return IndexType(orient(perspective, s, pos)
                      + pos.nnue_potion_zone_index_base()
                      + potionIndex * (pos.max_file() + 1) * (pos.max_rank() + 1)
@@ -60,9 +61,9 @@ namespace Stockfish::Eval::NNUE::Features {
   inline IndexType HalfKAv2Variants::make_potion_cooldown_index(Color perspective, Color potionColor,
                                                                 Variant::PotionType potion, int bit,
                                                                 Square ksq, const Position& pos) {
-    (void)perspective;
+    const int relativeColor = static_cast<int>(potionColor != perspective);
     const int potionIndex = static_cast<int>(potion)
-                            + Variant::POTION_TYPE_NB * static_cast<int>(potionColor);
+                            + Variant::POTION_TYPE_NB * relativeColor;
     return IndexType(bit
                      + pos.nnue_potion_cooldown_index_base()
                      + potionIndex * POTION_COOLDOWN_BITS

--- a/src/nnue/features/half_ka_v2_variants.h
+++ b/src/nnue/features/half_ka_v2_variants.h
@@ -44,25 +44,50 @@ namespace Stockfish::Eval::NNUE::Features {
     // Index of a feature for a given king position and another piece on some square
     static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq, const Position& pos);
 
-    // Index of a feature for a given king position and another piece in hand
+    // Index of a feature for a given king position and another piece in hand   
     static IndexType make_index(Color perspective, int handCount, Piece pc, Square ksq, const Position& pos);
+
+    // Index of a feature for a given king position and potion zone square
+    static IndexType make_potion_zone_index(Color perspective, Color potionColor,
+                                            Variant::PotionType potion, Square s,
+                                            Square ksq, const Position& pos);
+
+    // Index of a feature for a given king position and potion cooldown bit
+    static IndexType make_potion_cooldown_index(Color perspective, Color potionColor,
+                                                Variant::PotionType potion, int bit,
+                                                Square ksq, const Position& pos);
 
    public:
     // Feature name
     static constexpr const char* Name = "HalfKAv2(Friend)";
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t HashValue = 0x5f234cb8u;
+    static constexpr std::uint32_t HashValueNoPotions = 0x5f234cb8u;
+    static constexpr std::uint32_t HashValueWithPotions = 0x7c2d4f9eu;
+
+    static std::uint32_t get_hash_value() {
+      return currentNnueVariant && currentNnueVariant->nnuePotionZoneIndexBase >= 0
+             ? HashValueWithPotions
+             : HashValueNoPotions;
+    }
 
     // Number of feature dimensions
-    static constexpr IndexType Dimensions = static_cast<IndexType>(SQUARE_NB) * static_cast<IndexType>(SQUARE_NB) * 19;
+    static constexpr IndexType PotionZonePlanes =
+        COLOR_NB * Variant::POTION_TYPE_NB;
+    static constexpr IndexType PotionCooldownFeatures =
+        COLOR_NB * Variant::POTION_TYPE_NB * POTION_COOLDOWN_BITS;
+    static constexpr IndexType Dimensions =
+        static_cast<IndexType>(SQUARE_NB)
+        * (static_cast<IndexType>(SQUARE_NB) * (19 + PotionZonePlanes)
+           + PotionCooldownFeatures);
 
     static IndexType get_dimensions() {
       return currentNnueVariant->nnueDimensions;
     }
 
     // Maximum number of simultaneously active features.
-    static constexpr IndexType MaxActiveDimensions = 128;
+    static constexpr IndexType MaxActiveDimensions =
+        4 * static_cast<IndexType>(SQUARE_NB);
 
     // Get a list of indices for active features
     static void append_active_indices(

--- a/src/nnue/features/half_ka_v2_variants.h
+++ b/src/nnue/features/half_ka_v2_variants.h
@@ -63,7 +63,7 @@ namespace Stockfish::Eval::NNUE::Features {
 
     // Hash value embedded in the evaluation file
     static constexpr std::uint32_t HashValueNoPotions = 0x5f234cb8u;
-    static constexpr std::uint32_t HashValueWithPotions = 0x7c2d4f9eu;
+    static constexpr std::uint32_t HashValueWithPotions = 0x6a8f3c12u;
 
     static std::uint32_t get_hash_value() {
       return currentNnueVariant && currentNnueVariant->nnuePotionZoneIndexBase >= 0

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -193,8 +193,8 @@ namespace Stockfish::Eval::NNUE {
         OutputDimensions * sizeof(OutputType);
 
     // Hash value embedded in the evaluation file
-    static constexpr std::uint32_t get_hash_value() {
-      return FeatureSet::HashValue ^ OutputDimensions;
+    static std::uint32_t get_hash_value() {
+      return FeatureSet::get_hash_value() ^ OutputDimensions;
     }
 
     // Read network parameters

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1319,9 +1319,8 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = freeze_squares();
-  if (freezeExtra)
-      frozen &= ~freezeExtra;
+  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
+                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1628,9 +1627,8 @@ bool Position::pseudo_legal(const Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
 
-  Bitboard frozen = freeze_squares();
-  if (freezeExtra)
-      frozen &= ~freezeExtra;
+  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
+                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1786,9 +1784,8 @@ bool Position::gives_check(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = freeze_squares();
-  if (freezeExtra)
-      frozen &= ~freezeExtra;
+  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
+                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2540,10 +2540,12 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           if (potion_piece(potion) == NO_PIECE_TYPE)
               continue;
 
+          int cooldown = var->potionCooldown[pt];
+          int zoneLifetime = std::max(cooldown - 1, 0);
+
           if (gatingPotion == potion)
           {
-              int cooldown = var->potionCooldown[pt];
-              st->potionCooldown[us][pt] = std::max(cooldown - 1, 0);
+              st->potionCooldown[us][pt] = zoneLifetime;
               if (potion == Variant::POTION_FREEZE)
                   st->potionZones[us][pt] = freezeExtra;
               else if (potion == Variant::POTION_JUMP)
@@ -2554,7 +2556,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           else if (st->potionCooldown[us][pt] > 0)
           {
               --st->potionCooldown[us][pt];
-              if (st->potionCooldown[us][pt] == 0)
+              if (st->potionCooldown[us][pt] == 0
+                  || st->potionCooldown[us][pt] < zoneLifetime)
                   st->potionZones[us][pt] = Bitboard(0);
           }
           else

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1166,7 +1166,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
 
 Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard janggiCannons) const {
 
-  const Bitboard active = potions_enabled() ? ~freeze_squares() : ~Bitboard(0);
+  const Bitboard active = potions_enabled() ? ~freeze_squares(c) : ~Bitboard(0);
 
   // Use a faster version for variants with moderate rule variations
   if (var->fastAttacks)
@@ -1319,8 +1319,7 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
-                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
+  Bitboard frozen = freeze_squares(us);
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1651,8 +1650,7 @@ bool Position::pseudo_legal(const Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
 
-  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
-                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
+  Bitboard frozen = freeze_squares(us);
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1818,8 +1816,7 @@ bool Position::gives_check(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
-                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
+  Bitboard frozen = freeze_squares(sideToMove);
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -539,6 +539,28 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
   sideToMove = (token != (sfen ? 'w' : 'b') ? WHITE : BLACK);  // Invert colors for SFEN
   ss >> token;
 
+  if (!sfen && potions_enabled())
+  {
+      for (Color c : {WHITE, BLACK})
+          for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+          {
+              Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+              if (potion_piece(potion) == NO_PIECE_TYPE)
+                  continue;
+
+              int cooldown = st->potionCooldown[c][pt];
+              if (cooldown <= 0)
+              {
+                  st->potionZones[c][pt] = Bitboard(0);
+                  continue;
+              }
+
+              int zoneLifetime = std::max(var->potionCooldown[pt] - 1, 0);
+              if (cooldown < zoneLifetime || (cooldown == zoneLifetime && sideToMove == c))
+                  st->potionZones[c][pt] = Bitboard(0);
+          }
+  }
+
   // 3-4. Skip parsing castling and en passant flags if not present
   st->epSquares = 0;
   st->castlingKingSquare[WHITE] = st->castlingKingSquare[BLACK] = SQ_NONE;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1319,8 +1319,7 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
-                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
+  Bitboard frozen = freeze_move_squares();
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1523,7 +1522,7 @@ bool Position::legal(Move m) const {
       Square rto = to + (to_sq(m) > from_sq(m) ? WEST : EAST);
       if (is_gating(m) && (gating_square(m) == to || gating_square(m) == rto))  
           return false;
-      if (freeze_squares() & to_sq(m))
+      if (freeze_move_squares() & to_sq(m))
           return false;
 
       // Only the castling king piece is subject to attack checks

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1527,6 +1527,10 @@ bool Position::legal(Move m) const {
   // enemy attacks, it is delayed at a later time: now!
   if (type_of(m) == CASTLING)
   {
+      // Castling is never allowed while in check, even if self-check is otherwise permitted.
+      if (checkers())
+          return false;
+
       // After castling, the rook and king final positions are the same in
       // Chess960 as they would be in standard chess.
       to = make_square(to > from ? castling_kingside_file() : castling_queenside_file(), castling_rank(us));

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2544,16 +2544,22 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           {
               int cooldown = var->potionCooldown[pt];
               st->potionCooldown[us][pt] = std::max(cooldown - 1, 0);
+              if (potion == Variant::POTION_FREEZE)
+                  st->potionZones[us][pt] = freezeExtra;
+              else if (potion == Variant::POTION_JUMP)
+                  st->potionZones[us][pt] = jumpRemoved;
+              else
+                  st->potionZones[us][pt] = Bitboard(0);
           }
           else if (st->potionCooldown[us][pt] > 0)
+          {
               --st->potionCooldown[us][pt];
+              if (st->potionCooldown[us][pt] == 0)
+                  st->potionZones[us][pt] = Bitboard(0);
+          }
+          else
+              st->potionZones[us][pt] = Bitboard(0);
       }
-
-      st->potionZones[us][Variant::POTION_FREEZE] = gatingPotion == Variant::POTION_FREEZE ? freezeExtra : Bitboard(0);
-      st->potionZones[us][Variant::POTION_JUMP] = Bitboard(0);
-
-      st->potionZones[them][Variant::POTION_FREEZE] = Bitboard(0);
-      st->potionZones[them][Variant::POTION_JUMP] = Bitboard(0);
 
       togglePotionHashes(k);
   }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2571,8 +2571,6 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               continue;
 
           int cooldown = var->potionCooldown[pt];
-          int zoneLifetime = std::max(cooldown - 1, 0);
-
           if (gatingPotion == potion)
           {
               st->potionCooldown[us][pt] = cooldown;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1166,7 +1166,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
 
 Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard janggiCannons) const {
 
-  const Bitboard active = potions_enabled() ? ~freeze_squares() : ~Bitboard(0);
+  const Bitboard active = potions_enabled() ? ~frozen_squares(c) : ~Bitboard(0);
 
   // Use a faster version for variants with moderate rule variations
   if (var->fastAttacks)
@@ -1319,8 +1319,7 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
-                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
+  Bitboard frozen = frozen_squares(us);
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1329,6 +1328,19 @@ bool Position::legal(Move m) const {
   assert(color_of(moved_piece(m)) == us);
   assert(!count(us, royal) || piece_on(square(us, royal)) == make_piece(us, royal));
   assert(board_bb() & to);
+
+  Piece captured = NO_PIECE;
+  if (capture(m))
+  {
+      Square csq = type_of(m) == EN_PASSANT ? capture_square(to) : to;
+      captured = piece_on(csq);
+  }
+  bool extinctionCapture = captured != NO_PIECE
+                        && color_of(captured) == ~us
+                        && type_of(captured) == royal
+                        && extinction_value() != VALUE_NONE
+                        && (extinction_piece_types() & royal)
+                        && count(~us, royal) <= extinction_piece_count() + 1;
 
   // Illegal checks
   if ((!checking_permitted() || (sittuyin_promotion() && type_of(m) == PROMOTION) || (!drop_checks() && type_of(m) == DROP)) && gives_check(m))
@@ -1523,7 +1535,7 @@ bool Position::legal(Move m) const {
       Square rto = to + (to_sq(m) > from_sq(m) ? WEST : EAST);
       if (is_gating(m) && (gating_square(m) == to || gating_square(m) == rto))  
           return false;
-      if (freeze_squares() & to_sq(m))
+      if (frozen_squares(us) & to_sq(m))
           return false;
 
       // Only the castling king piece is subject to attack checks
@@ -1560,7 +1572,7 @@ bool Position::legal(Move m) const {
   // If the moving piece is a king, check whether the destination square is
   // attacked by the opponent.
   if (type_of(moved_piece(m)) == royal)
-      return !attackers_to(to, occupied, ~us);
+      return extinctionCapture || !attackers_to(to, occupied, ~us);
 
   // Return early when without king
   if (!count(us, royal))
@@ -1573,6 +1585,9 @@ bool Position::legal(Move m) const {
       janggiCannons ^= to;
 
   // A non-king move is legal if the king is not under attack after the move.
+  if (extinctionCapture)
+      return true;
+
   return !(attackers_to(square(us, royal), occupied, ~us, janggiCannons) & ~SquareBB[to]);
 }
 
@@ -1628,8 +1643,7 @@ bool Position::pseudo_legal(const Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
 
-  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
-                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
+  Bitboard frozen = frozen_squares(us);
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1691,6 +1705,19 @@ bool Position::pseudo_legal(const Move m) const {
           return false;
   }
 
+  Piece captured = NO_PIECE;
+  if (capture(m))
+  {
+      Square csq = type_of(m) == EN_PASSANT ? capture_square(to) : to;
+      captured = piece_on(csq);
+  }
+  bool extinctionCapture = captured != NO_PIECE
+                        && color_of(captured) == ~us
+                        && type_of(captured) == royal
+                        && extinction_value() != VALUE_NONE
+                        && (extinction_piece_types() & royal)
+                        && count(~us, royal) <= extinction_piece_count() + 1;
+
   // Handle the special case of a pawn move
   if (type_of(pc) == PAWN)
   {
@@ -1722,6 +1749,8 @@ bool Position::pseudo_legal(const Move m) const {
   // kind of moves are filtered out here.
   if (checkers() && !(checkers() & non_sliding_riders()))
   {
+      if (extinctionCapture)
+          return true;
       if (type_of(pc) != royal)
       {
           // Double check? In this case a king move is required
@@ -1777,8 +1806,7 @@ bool Position::gives_check(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
-                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
+  Bitboard frozen = frozen_squares(sideToMove);
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1319,7 +1319,8 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = freeze_squares();
+  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
+                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1535,7 +1536,7 @@ bool Position::legal(Move m) const {
       Square rto = to + (to_sq(m) > from_sq(m) ? WEST : EAST);
       if (is_gating(m) && (gating_square(m) == to || gating_square(m) == rto))  
           return false;
-      if (freeze_squares() & to_sq(m))
+      if (frozen & to_sq(m))
           return false;
 
       // Only the castling king piece is subject to attack checks
@@ -1586,6 +1587,9 @@ bool Position::legal(Move m) const {
 
   // A non-king move is legal if the king is not under attack after the move.
   if (extinctionCapture)
+      return true;
+
+  if (allow_self_check())
       return true;
 
   return !(attackers_to(square(us, royal), occupied, ~us, janggiCannons) & ~SquareBB[to]);
@@ -1643,15 +1647,17 @@ bool Position::pseudo_legal(const Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
 
-  Bitboard frozen = freeze_squares();
+  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
+                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
       return false;
 
+  bool needsEvasion = checkers() && !allow_self_check();
   if (type_of(m) != NORMAL || (is_gating(m) && gatingPotion == Variant::POTION_TYPE_NB))
-      return checkers() ? MoveList<    EVASIONS>(*this).contains(m)
-                        : MoveList<NON_EVASIONS>(*this).contains(m);
+      return needsEvasion ? MoveList<    EVASIONS>(*this).contains(m)
+                          : MoveList<NON_EVASIONS>(*this).contains(m);
 
   //if walling, and walling is not optional, or they didn't move, do the checks.
   if (walling() && (!var->wallOrMove || (from==to)))
@@ -1808,7 +1814,8 @@ bool Position::gives_check(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = freeze_squares();
+  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
+                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2902,6 +2902,7 @@ bool Position::see_ge(Move m, Value threshold) const {
       return VALUE_ZERO >= threshold;
 
   Square from = from_sq(m), to = to_sq(m);
+  Piece victim = piece_on(to);
 
   // nCheck
   if (check_counting() && color_of(moved_piece(m)) == sideToMove && gives_check(m))
@@ -2924,7 +2925,6 @@ bool Position::see_ge(Move m, Value threshold) const {
   if (must_capture() || !checking_permitted() || is_gating(m) || count<CLOBBER_PIECE>() == count<ALL_PIECES>())
       return VALUE_ZERO >= threshold;
 
-  Piece victim = piece_on(to);
   int victimValue = PieceValue[MG][victim];
   if (victim != NO_PIECE && color_of(victim) == color_of(moved_piece(m)) && self_capture())
       victimValue = -victimValue;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2594,6 +2594,15 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               st->potionZones[us][pt] = Bitboard(0);
       }
 
+      if (potion_piece(Variant::POTION_JUMP) != NO_PIECE_TYPE)
+      {
+          int zoneLifetime = std::max(var->potionCooldown[Variant::POTION_JUMP] - 1, 0);
+          Color opp = ~us;
+          if (st->potionZones[opp][Variant::POTION_JUMP]
+              && st->potionCooldown[opp][Variant::POTION_JUMP] == zoneLifetime)
+              st->potionZones[opp][Variant::POTION_JUMP] = Bitboard(0);
+      }
+
       togglePotionHashes(k);
   }
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1166,42 +1166,45 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
 
 Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard janggiCannons) const {
 
+  const Bitboard active = potions_enabled() ? ~freeze_squares() : ~Bitboard(0);
+
   // Use a faster version for variants with moderate rule variations
   if (var->fastAttacks)
   {
-      return  (pawn_attacks_bb(~c, s)          & pieces(c, PAWN))
-            | (attacks_bb<KNIGHT>(s)           & pieces(c, KNIGHT, ARCHBISHOP, CHANCELLOR))
-            | (attacks_bb<  ROOK>(s, occupied) & pieces(c, ROOK, QUEEN, CHANCELLOR))
-            | (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN, ARCHBISHOP))
-            | (attacks_bb<KING>(s)             & pieces(c, KING, COMMONER));
+      return  (pawn_attacks_bb(~c, s)          & (pieces(c, PAWN) & active))
+            | (attacks_bb<KNIGHT>(s)           & (pieces(c, KNIGHT, ARCHBISHOP, CHANCELLOR) & active))
+            | (attacks_bb<  ROOK>(s, occupied) & (pieces(c, ROOK, QUEEN, CHANCELLOR) & active))
+            | (attacks_bb<BISHOP>(s, occupied) & (pieces(c, BISHOP, QUEEN, ARCHBISHOP) & active))
+            | (attacks_bb<KING>(s)             & (pieces(c, KING, COMMONER) & active));
   }
 
   // Use a faster version for selected fairy pieces
   if (var->fastAttacks2)
   {
-      return  (pawn_attacks_bb(~c, s)             & pieces(c, PAWN, BREAKTHROUGH_PIECE, GOLD))
-            | (attacks_bb<KNIGHT>(s)              & pieces(c, KNIGHT))
-            | (attacks_bb<  ROOK>(s, occupied)    & (  pieces(c, ROOK, QUEEN, DRAGON)
-                                                     | (pieces(c, LANCE) & PseudoAttacks[~c][LANCE][s])))
-            | (attacks_bb<BISHOP>(s, occupied)    & pieces(c, BISHOP, QUEEN, DRAGON_HORSE))
-            | (attacks_bb<KING>(s)                & pieces(c, KING, COMMONER))
-            | (attacks_bb<FERS>(s)                & pieces(c, FERS, DRAGON, SILVER))
-            | (attacks_bb<WAZIR>(s)               & pieces(c, WAZIR, DRAGON_HORSE, GOLD))
-            | (LeaperAttacks[~c][SHOGI_KNIGHT][s] & pieces(c, SHOGI_KNIGHT))
-            | (LeaperAttacks[~c][SHOGI_PAWN][s]   & pieces(c, SHOGI_PAWN, SILVER));
+      return  (pawn_attacks_bb(~c, s)             & (pieces(c, PAWN, BREAKTHROUGH_PIECE, GOLD) & active))
+            | (attacks_bb<KNIGHT>(s)              & (pieces(c, KNIGHT) & active))
+            | (attacks_bb<  ROOK>(s, occupied)    & (  (pieces(c, ROOK, QUEEN, DRAGON) & active)
+                                                     | ((pieces(c, LANCE) & active) & PseudoAttacks[~c][LANCE][s])))
+            | (attacks_bb<BISHOP>(s, occupied)    & (pieces(c, BISHOP, QUEEN, DRAGON_HORSE) & active))
+            | (attacks_bb<KING>(s)                & (pieces(c, KING, COMMONER) & active))
+            | (attacks_bb<FERS>(s)                & (pieces(c, FERS, DRAGON, SILVER) & active))
+            | (attacks_bb<WAZIR>(s)               & (pieces(c, WAZIR, DRAGON_HORSE, GOLD) & active))
+            | (LeaperAttacks[~c][SHOGI_KNIGHT][s] & (pieces(c, SHOGI_KNIGHT) & active))
+            | (LeaperAttacks[~c][SHOGI_PAWN][s]   & (pieces(c, SHOGI_PAWN, SILVER) & active));
   }
 
   Bitboard b = 0;
   for (PieceSet ps = piece_types(); ps;)
   {
       PieceType pt = pop_lsb(ps);
-      if (board_bb(c, pt) & s)
+      Bitboard activePieces = pieces(c, pt) & active;
+      if ((board_bb(c, pt) & s) && activePieces)
       {
           PieceType move_pt = pt == KING ? king_type() : pt;
           // Consider asymmetrical moves (e.g., horse)
           if (AttackRiderTypes[move_pt] & ASYMMETRICAL_RIDERS)
           {
-              Bitboard asymmetricals = PseudoAttacks[~c][move_pt][s] & pieces(c, pt);
+              Bitboard asymmetricals = PseudoAttacks[~c][move_pt][s] & activePieces;
               while (asymmetricals)
               {
                   Square s2 = pop_lsb(asymmetricals);
@@ -1210,9 +1213,11 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard j
               }
           }
           else if (pt == JANGGI_CANNON)
-              b |= attacks_bb(~c, move_pt, s, occupied) & attacks_bb(~c, move_pt, s, occupied & ~janggiCannons) & pieces(c, JANGGI_CANNON);
+              b |= attacks_bb(~c, move_pt, s, occupied)
+                & attacks_bb(~c, move_pt, s, occupied & ~janggiCannons)
+                & activePieces;
           else
-              b |= attacks_bb(~c, move_pt, s, occupied) & pieces(c, pt);
+              b |= attacks_bb(~c, move_pt, s, occupied) & activePieces;
       }
   }
 
@@ -1221,19 +1226,19 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard j
   {
       Bitboard diags = 0;
       if (king_type() == WAZIR)
-          diags |= attacks_bb(~c, FERS, s, occupied) & pieces(c, KING);
-      diags |= attacks_bb(~c, FERS, s, occupied) & pieces(c, WAZIR);
-      diags |= attacks_bb(~c, PAWN, s, occupied) & pieces(c, SOLDIER);
-      diags |= rider_attacks_bb<RIDER_BISHOP>(s, occupied) & pieces(c, ROOK);
+          diags |= attacks_bb(~c, FERS, s, occupied) & (pieces(c, KING) & active);
+      diags |= attacks_bb(~c, FERS, s, occupied) & (pieces(c, WAZIR) & active);
+      diags |= attacks_bb(~c, PAWN, s, occupied) & (pieces(c, SOLDIER) & active);
+      diags |= rider_attacks_bb<RIDER_BISHOP>(s, occupied) & (pieces(c, ROOK) & active);
       diags |=  rider_attacks_bb<RIDER_CANNON_DIAG>(s, occupied)
               & rider_attacks_bb<RIDER_CANNON_DIAG>(s, occupied & ~janggiCannons)
-              & pieces(c, JANGGI_CANNON);
+              & (pieces(c, JANGGI_CANNON) & active);
       b |= diags & diagonal_lines();
   }
 
   // Unpromoted soldiers
   if (b & pieces(SOLDIER) && relative_rank(c, s, max_rank()) < var->soldierPromotionRank)
-      b ^= b & pieces(SOLDIER) & ~PseudoAttacks[~c][SHOGI_PAWN][s];
+      b ^= b & (pieces(SOLDIER) & active) & ~PseudoAttacks[~c][SHOGI_PAWN][s];
 
   return b;
 }
@@ -1626,8 +1631,16 @@ bool Position::pseudo_legal(const Move m) const {
       return false;
 
   if (type_of(m) != NORMAL || is_gating(m))
+  {
+      if (is_gating(m) && potions_enabled() && checkers())
+      {
+          Variant::PotionType potion = potion_type_from_piece(var, gating_type(m));
+          if (potion != Variant::POTION_TYPE_NB)
+              return legal(m);
+      }
       return checkers() ? MoveList<    EVASIONS>(*this).contains(m)
                         : MoveList<NON_EVASIONS>(*this).contains(m);
+  }
 
   //if walling, and walling is not optional, or they didn't move, do the checks.
   if (walling() && (!var->wallOrMove || (from==to)))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1319,7 +1319,10 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  if (type_of(m) != DROP && (freeze_squares() & from))
+  Bitboard frozen = freeze_squares();
+  if (freezeExtra)
+      frozen &= ~freezeExtra;
+  if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
       return false;
@@ -1625,7 +1628,10 @@ bool Position::pseudo_legal(const Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
 
-  if (type_of(m) != DROP && (freeze_squares() & from))
+  Bitboard frozen = freeze_squares();
+  if (freezeExtra)
+      frozen &= ~freezeExtra;
+  if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
       return false;
@@ -1780,7 +1786,10 @@ bool Position::gives_check(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  if (type_of(m) != DROP && (freeze_squares() & from))
+  Bitboard frozen = freeze_squares();
+  if (freezeExtra)
+      frozen &= ~freezeExtra;
+  if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
       return false;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1321,7 +1321,6 @@ bool Position::legal(Move m) const {
   Square to = to_sq(m);
 
   Bitboard freezeExtra = 0;
-  Bitboard freezeBlock = 0;
   Bitboard jumpRemoved = 0;
   Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
   if (is_gating(m))
@@ -1332,10 +1331,7 @@ bool Position::legal(Move m) const {
           if (!can_cast_potion(us, gatingPotion))
               return false;
           if (gatingPotion == Variant::POTION_FREEZE)
-          {
               freezeExtra = freeze_zone_from_square(gating_square(m));
-              freezeBlock = freeze_block_zone_from_square(gating_square(m));
-          }
           else if (gatingPotion == Variant::POTION_JUMP)
           {
               jumpRemoved = square_bb(gating_square(m));
@@ -1348,8 +1344,10 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP && (freezeBlock & from))
-      return false;
+  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP) {
+      if (freezeExtra & from)
+          return false;
+  }
 
     Bitboard jumpMask = potions_enabled() ? jump_squares(us) : Bitboard(0);
     if (type_of(m) != DROP && (jumpMask & to) && !capture(m))
@@ -1662,7 +1660,6 @@ bool Position::pseudo_legal(const Move m) const {
   // Use a slower but simpler function for uncommon cases
   // yet we skip the legality check of MoveList<LEGAL>().
   Bitboard freezeExtra = 0;
-  Bitboard freezeBlock = 0;
   Bitboard jumpRemoved = 0;
   Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
   if (is_gating(m))
@@ -1673,10 +1670,7 @@ bool Position::pseudo_legal(const Move m) const {
           if (!can_cast_potion(us, gatingPotion))
               return false;
           if (gatingPotion == Variant::POTION_FREEZE)
-          {
               freezeExtra = freeze_zone_from_square(gating_square(m));
-              freezeBlock = freeze_block_zone_from_square(gating_square(m));
-          }
           else if (gatingPotion == Variant::POTION_JUMP)
           {
               jumpRemoved = square_bb(gating_square(m));
@@ -1688,8 +1682,10 @@ bool Position::pseudo_legal(const Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
 
-  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP && (freezeBlock & from))
-      return false;
+  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP) {
+      if (freezeExtra & from)
+          return false;
+  }
 
     Bitboard jumpMask = potions_enabled() ? jump_squares(us) : Bitboard(0);
     if (type_of(m) != DROP && (jumpMask & to) && !capture(m))
@@ -1841,7 +1837,6 @@ bool Position::gives_check(Move m) const {
   Square to = to_sq(m);
 
   Bitboard freezeExtra = 0;
-  Bitboard freezeBlock = 0;
   Bitboard jumpRemoved = 0;
   Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
   if (is_gating(m))
@@ -1852,10 +1847,7 @@ bool Position::gives_check(Move m) const {
           if (!can_cast_potion(sideToMove, gatingPotion))
               return false;
           if (gatingPotion == Variant::POTION_FREEZE)
-          {
               freezeExtra = freeze_zone_from_square(gating_square(m));
-              freezeBlock = freeze_block_zone_from_square(gating_square(m));
-          }
           else if (gatingPotion == Variant::POTION_JUMP)
           {
               jumpRemoved = square_bb(gating_square(m));
@@ -1868,8 +1860,10 @@ bool Position::gives_check(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP && (freezeBlock & from))
-      return false;
+  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP) {
+      if (freezeExtra & from)
+          return false;
+  }
 
   Bitboard frozen = freeze_squares(sideToMove);
   if (type_of(m) != DROP && (frozen & from))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1351,9 +1351,9 @@ bool Position::legal(Move m) const {
   if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP && (freezeBlock & from))
       return false;
 
-  Bitboard jumpMask = potions_enabled() ? jump_squares(us) : Bitboard(0);
-  if (type_of(m) != DROP && (jumpMask & to))
-      return false;
+    Bitboard jumpMask = potions_enabled() ? jump_squares(us) : Bitboard(0);
+    if (type_of(m) != DROP && (jumpMask & to) && !capture(m))
+        return false;
 
   Bitboard frozen = freeze_squares(us);
   if (type_of(m) != DROP && (frozen & from))
@@ -1691,9 +1691,9 @@ bool Position::pseudo_legal(const Move m) const {
   if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP && (freezeBlock & from))
       return false;
 
-  Bitboard jumpMask = potions_enabled() ? jump_squares(us) : Bitboard(0);
-  if (type_of(m) != DROP && (jumpMask & to))
-      return false;
+    Bitboard jumpMask = potions_enabled() ? jump_squares(us) : Bitboard(0);
+    if (type_of(m) != DROP && (jumpMask & to) && !capture(m))
+        return false;
 
   Bitboard frozen = freeze_squares(us);
   if (type_of(m) != DROP && (frozen & from))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1607,16 +1607,17 @@ bool Position::pseudo_legal(const Move m) const {
   // yet we skip the legality check of MoveList<LEGAL>().
   Bitboard freezeExtra = 0;
   Bitboard jumpRemoved = 0;
+  Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
   if (is_gating(m))
   {
-      Variant::PotionType potion = potion_type_from_piece(var, gating_type(m));
-      if (potion != Variant::POTION_TYPE_NB)
+      gatingPotion = potion_type_from_piece(var, gating_type(m));
+      if (gatingPotion != Variant::POTION_TYPE_NB)
       {
-          if (!can_cast_potion(us, potion))
+          if (!can_cast_potion(us, gatingPotion))
               return false;
-          if (potion == Variant::POTION_FREEZE)
+          if (gatingPotion == Variant::POTION_FREEZE)
               freezeExtra = freeze_zone_from_square(gating_square(m));
-          else if (potion == Variant::POTION_JUMP)
+          else if (gatingPotion == Variant::POTION_JUMP)
           {
               jumpRemoved = square_bb(gating_square(m));
               if (!piece_on(gating_square(m)))
@@ -1634,17 +1635,9 @@ bool Position::pseudo_legal(const Move m) const {
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
       return false;
 
-  if (type_of(m) != NORMAL || is_gating(m))
-  {
-      if (is_gating(m) && potions_enabled() && checkers())
-      {
-          Variant::PotionType potion = potion_type_from_piece(var, gating_type(m));
-          if (potion != Variant::POTION_TYPE_NB)
-              return legal(m);
-      }
+  if (type_of(m) != NORMAL || (is_gating(m) && gatingPotion == Variant::POTION_TYPE_NB))
       return checkers() ? MoveList<    EVASIONS>(*this).contains(m)
                         : MoveList<NON_EVASIONS>(*this).contains(m);
-  }
 
   //if walling, and walling is not optional, or they didn't move, do the checks.
   if (walling() && (!var->wallOrMove || (from==to)))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2575,7 +2575,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
           if (gatingPotion == potion)
           {
-              st->potionCooldown[us][pt] = zoneLifetime;
+              st->potionCooldown[us][pt] = cooldown;
               if (potion == Variant::POTION_FREEZE)
                   st->potionZones[us][pt] = freezeExtra;
               else if (potion == Variant::POTION_JUMP)
@@ -2583,24 +2583,26 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               else
                   st->potionZones[us][pt] = Bitboard(0);
           }
-          else if (st->potionCooldown[us][pt] > 0)
-          {
-              --st->potionCooldown[us][pt];
-              if (st->potionCooldown[us][pt] == 0
-                  || st->potionCooldown[us][pt] < zoneLifetime)
-                  st->potionZones[us][pt] = Bitboard(0);
-          }
-          else
+          else if (st->potionCooldown[us][pt] == 0)
               st->potionZones[us][pt] = Bitboard(0);
       }
 
-      if (potion_piece(Variant::POTION_JUMP) != NO_PIECE_TYPE)
+      Color opp = ~us;
+      for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
       {
-          int zoneLifetime = std::max(var->potionCooldown[Variant::POTION_JUMP] - 1, 0);
-          Color opp = ~us;
-          if (st->potionZones[opp][Variant::POTION_JUMP]
-              && st->potionCooldown[opp][Variant::POTION_JUMP] == zoneLifetime)
-              st->potionZones[opp][Variant::POTION_JUMP] = Bitboard(0);
+          Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+          if (potion_piece(potion) == NO_PIECE_TYPE)
+              continue;
+
+          int zoneLifetime = std::max(var->potionCooldown[pt] - 1, 0);
+          if (st->potionCooldown[opp][pt] > 0)
+          {
+              --st->potionCooldown[opp][pt];
+              if (st->potionCooldown[opp][pt] <= zoneLifetime)
+                  st->potionZones[opp][pt] = Bitboard(0);
+          }
+          else
+              st->potionZones[opp][pt] = Bitboard(0);
       }
 
       togglePotionHashes(k);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1166,7 +1166,7 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
 
 Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard janggiCannons) const {
 
-  const Bitboard active = potions_enabled() ? ~frozen_squares(c) : ~Bitboard(0);
+  const Bitboard active = potions_enabled() ? ~freeze_squares() : ~Bitboard(0);
 
   // Use a faster version for variants with moderate rule variations
   if (var->fastAttacks)
@@ -1319,7 +1319,7 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = frozen_squares(us);
+  Bitboard frozen = freeze_squares();
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1535,7 +1535,7 @@ bool Position::legal(Move m) const {
       Square rto = to + (to_sq(m) > from_sq(m) ? WEST : EAST);
       if (is_gating(m) && (gating_square(m) == to || gating_square(m) == rto))  
           return false;
-      if (frozen_squares(us) & to_sq(m))
+      if (freeze_squares() & to_sq(m))
           return false;
 
       // Only the castling king piece is subject to attack checks
@@ -1643,7 +1643,7 @@ bool Position::pseudo_legal(const Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
 
-  Bitboard frozen = frozen_squares(us);
+  Bitboard frozen = freeze_squares();
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1751,6 +1751,8 @@ bool Position::pseudo_legal(const Move m) const {
   {
       if (extinctionCapture)
           return true;
+      if (gatingPotion == Variant::POTION_FREEZE && freezeExtra && !(checkers() & ~freezeExtra))
+          return true;
       if (type_of(pc) != royal)
       {
           // Double check? In this case a king move is required
@@ -1806,7 +1808,7 @@ bool Position::gives_check(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = frozen_squares(sideToMove);
+  Bitboard frozen = freeze_squares();
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1352,7 +1352,9 @@ bool Position::legal(Move m) const {
 
       // Will the gate be blocked by king or rook?
       Square rto = to + (to_sq(m) > from_sq(m) ? WEST : EAST);
-      if (is_gating(m) && (gating_square(m) == to || gating_square(m) == rto))
+      if (is_gating(m) && (gating_square(m) == to || gating_square(m) == rto))  
+          return false;
+      if (freeze_squares() & to_sq(m))
           return false;
 
       // Non-royal pieces can not be impeded from castling

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -45,12 +45,59 @@ namespace {
 
   inline Variant::PotionType potion_type_from_piece(const Variant* var, PieceType pt) {
     if (!var || !var->potions)
-        return static_cast<Variant::PotionType>(Variant::POTION_TYPE_NB);
+        return static_cast<Variant::PotionType>(Variant::POTION_TYPE_NB);       
     if (pt == var->potionPiece[Variant::POTION_FREEZE])
         return Variant::POTION_FREEZE;
     if (pt == var->potionPiece[Variant::POTION_JUMP])
         return Variant::POTION_JUMP;
     return static_cast<Variant::PotionType>(Variant::POTION_TYPE_NB);
+  }
+
+  inline Square potion_zone_center(const Position& pos, Variant::PotionType potion,
+                                   Bitboard zone) {
+    if (zone == Bitboard(0))
+        return SQ_NONE;
+    if (potion == Variant::POTION_JUMP)
+        return lsb(zone);
+    Bitboard candidates = zone;
+    while (candidates)
+    {
+        Square s = pop_lsb(candidates);
+        if (pos.freeze_zone_from_square(s) == zone)
+            return s;
+    }
+    return lsb(zone);
+  }
+
+  inline Bitboard potion_zone_from_center(const Position& pos, Variant::PotionType potion,
+                                          Square s) {
+    if (s == SQ_NONE)
+        return Bitboard(0);
+    if (potion == Variant::POTION_FREEZE)
+        return pos.freeze_zone_from_square(s);
+    return square_bb(s);
+  }
+
+  inline Square parse_fen_square(const Position& pos, const std::string& token) {
+    if (token.size() < 2)
+        return SQ_NONE;
+    char fileChar = char(tolower(token[0]));
+    if (fileChar < 'a' || fileChar > char('a' + pos.max_file()))
+        return SQ_NONE;
+    int file = fileChar - 'a';
+    int rank = 0;
+    for (size_t i = 1; i < token.size(); ++i)
+    {
+        if (!isdigit(token[i]))
+            return SQ_NONE;
+        rank = rank * 10 + (token[i] - '0');
+    }
+    if (rank <= 0)
+        return SQ_NONE;
+    int rankIndex = rank - 1;
+    if (rankIndex > pos.max_rank())
+        return SQ_NONE;
+    return make_square(File(file), Rank(rankIndex));
   }
 
   struct SpellContextScope {
@@ -407,7 +454,87 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
               add_to_hand(Piece(idx));
       }
 
+  if (!sfen && potions_enabled())
+  {
+      std::string potionState;
+      ss >> std::ws;
+      if (ss.peek() == '{')
+      {
+          ss >> token;
+          while (ss >> token)
+          {
+              if (token == '}')
+                  break;
+              if (!isspace(token))
+                  potionState.push_back(char(token));
+          }
+      }
+
+      auto parse_potion_state = [&](const std::string& state) {
+          size_t start = 0;
+          const int maxCooldown = (1u << POTION_COOLDOWN_BITS) - 1;
+          while (start < state.size())
+          {
+              size_t end = state.find(',', start);
+              std::string entry = state.substr(start, end == std::string::npos ? end : end - start);
+              if (entry.size() >= 4)
+              {
+                  char pieceChar = entry[0];
+                  Color c = islower(pieceChar) ? BLACK : WHITE;
+                  Variant::PotionType potion = static_cast<Variant::PotionType>(Variant::POTION_TYPE_NB);
+                  for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+                  {
+                      Variant::PotionType ptEnum = static_cast<Variant::PotionType>(pt);
+                      PieceType potionPiece = potion_piece(ptEnum);
+                      if (potionPiece == NO_PIECE_TYPE)
+                          continue;
+                      char expected = piece_to_char()[make_piece(WHITE, potionPiece)];
+                      if (tolower(expected) == tolower(pieceChar))
+                      {
+                          potion = ptEnum;
+                          break;
+                      }
+                  }
+
+                  size_t at = entry.find('@', 1);
+                  size_t colon = entry.find(':', at == std::string::npos ? 0 : at + 1);
+                  if (potion != Variant::POTION_TYPE_NB && at != std::string::npos && colon != std::string::npos)
+                  {
+                      std::string squareToken = entry.substr(at + 1, colon - at - 1);
+                      std::string cooldownToken = entry.substr(colon + 1);
+                      Square center = SQ_NONE;
+                      if (!squareToken.empty() && squareToken != "-")
+                          center = parse_fen_square(*this, squareToken);
+
+                      int cooldown = 0;
+                      for (char ch : cooldownToken)
+                      {
+                          if (!isdigit(ch))
+                          {
+                              cooldown = 0;
+                              break;
+                          }
+                          cooldown = cooldown * 10 + (ch - '0');
+                      }
+                      if (cooldown > maxCooldown)
+                          cooldown = maxCooldown;
+
+                      st->potionCooldown[c][potion] = cooldown;
+                      st->potionZones[c][potion] = potion_zone_from_center(*this, potion, center);
+                  }
+              }
+              if (end == std::string::npos)
+                  break;
+              start = end + 1;
+          }
+      };
+
+      if (!potionState.empty())
+          parse_potion_state(potionState);
+  }
+
   // 2. Active color
+  ss >> std::ws;
   ss >> token;
   sideToMove = (token != (sfen ? 'w' : 'b') ? WHITE : BLACK);  // Invert colors for SFEN
   ss >> token;
@@ -839,6 +966,38 @@ string Position::fen(bool sfen, bool showPromoted, int countStarted, std::string
                   ss << std::string(pieceCountInHand[c][pt], piece_to_char()[make_piece(c, pt)]);
               }
       ss << ']';
+  }
+
+  if (potions_enabled())
+  {
+      std::string potionState;
+      const int maxCooldown = (1u << POTION_COOLDOWN_BITS) - 1;
+      for (Color c : {WHITE, BLACK})
+          for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+          {
+              Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+              PieceType potionPiece = potion_piece(potion);
+              if (potionPiece == NO_PIECE_TYPE)
+                  continue;
+              if (!potionState.empty())
+                  potionState += ",";
+              potionState += piece_to_char()[make_piece(c, potionPiece)];
+              potionState += "@";
+              Bitboard zone = potion_zone(c, potion);
+              if (zone)
+                  potionState += UCI::square(*this, potion_zone_center(*this, potion, zone));
+              else
+                  potionState += "-";
+              potionState += ":";
+              int cooldown = potion_cooldown(c, potion);
+              if (cooldown < 0)
+                  cooldown = 0;
+              if (cooldown > maxCooldown)
+                  cooldown = maxCooldown;
+              potionState += std::to_string(cooldown);
+          }
+      if (!potionState.empty())
+          ss << " {" << potionState << "}";
   }
 
   ss << (sideToMove == WHITE ? " w " : " b ");
@@ -1357,8 +1516,8 @@ bool Position::legal(Move m) const {
       if (freeze_squares() & to_sq(m))
           return false;
 
-      // Non-royal pieces can not be impeded from castling
-      if (type_of(piece_on(from)) != KING)
+      // Only the castling king piece is subject to attack checks
+      if (type_of(piece_on(from)) != castling_king_piece(us))
           return true;
 
       for (Square s = to; s != from; s += step)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1166,6 +1166,9 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
 
 Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard janggiCannons) const {
 
+  if (potions_enabled())
+      occupied &= ~jump_squares(c);
+
   const Bitboard active = potions_enabled() ? ~freeze_squares(c) : ~Bitboard(0);
 
   // Use a faster version for variants with moderate rule variations
@@ -1296,6 +1299,7 @@ bool Position::legal(Move m) const {
   Square to = to_sq(m);
 
   Bitboard freezeExtra = 0;
+  Bitboard freezeBlock = 0;
   Bitboard jumpRemoved = 0;
   Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
   if (is_gating(m))
@@ -1306,7 +1310,10 @@ bool Position::legal(Move m) const {
           if (!can_cast_potion(us, gatingPotion))
               return false;
           if (gatingPotion == Variant::POTION_FREEZE)
+          {
               freezeExtra = freeze_zone_from_square(gating_square(m));
+              freezeBlock = freeze_block_zone_from_square(gating_square(m));
+          }
           else if (gatingPotion == Variant::POTION_JUMP)
           {
               jumpRemoved = square_bb(gating_square(m));
@@ -1319,10 +1326,15 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
+  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP && (freezeBlock & from))
+      return false;
+
+  Bitboard jumpMask = potions_enabled() ? jump_squares(us) : Bitboard(0);
+  if (type_of(m) != DROP && (jumpMask & to))
+      return false;
+
   Bitboard frozen = freeze_squares(us);
   if (type_of(m) != DROP && (frozen & from))
-      return false;
-  if (jumpRemoved && (square_bb(to) & jumpRemoved))
       return false;
 
   assert(color_of(moved_piece(m)) == us);
@@ -1628,6 +1640,7 @@ bool Position::pseudo_legal(const Move m) const {
   // Use a slower but simpler function for uncommon cases
   // yet we skip the legality check of MoveList<LEGAL>().
   Bitboard freezeExtra = 0;
+  Bitboard freezeBlock = 0;
   Bitboard jumpRemoved = 0;
   Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
   if (is_gating(m))
@@ -1638,7 +1651,10 @@ bool Position::pseudo_legal(const Move m) const {
           if (!can_cast_potion(us, gatingPotion))
               return false;
           if (gatingPotion == Variant::POTION_FREEZE)
+          {
               freezeExtra = freeze_zone_from_square(gating_square(m));
+              freezeBlock = freeze_block_zone_from_square(gating_square(m));
+          }
           else if (gatingPotion == Variant::POTION_JUMP)
           {
               jumpRemoved = square_bb(gating_square(m));
@@ -1650,10 +1666,15 @@ bool Position::pseudo_legal(const Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
 
+  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP && (freezeBlock & from))
+      return false;
+
+  Bitboard jumpMask = potions_enabled() ? jump_squares(us) : Bitboard(0);
+  if (type_of(m) != DROP && (jumpMask & to))
+      return false;
+
   Bitboard frozen = freeze_squares(us);
   if (type_of(m) != DROP && (frozen & from))
-      return false;
-  if (jumpRemoved && (square_bb(to) & jumpRemoved))
       return false;
 
   bool needsEvasion = checkers() && !allow_self_check();
@@ -1726,6 +1747,10 @@ bool Position::pseudo_legal(const Move m) const {
                         && (extinction_piece_types() & royal)
                         && count(~us, royal) <= extinction_piece_count() + 1;
 
+  Bitboard occupied = pieces();
+  if (potions_enabled())
+      occupied &= ~jump_squares(us);
+
   // Handle the special case of a pawn move
   if (type_of(pc) == PAWN)
   {
@@ -1736,13 +1761,13 @@ bool Position::pseudo_legal(const Move m) const {
 
       if (   !(pawn_attacks_bb(us, from)
               & (self_capture() ? pieces() : pieces(~us)) & to)     // Not a capture
-          && !((from + pawn_push(us) == to) && !(pieces() & to)) // Not a single push
+          && !((from + pawn_push(us) == to) && !(occupied & to)) // Not a single push
           && !(   (from + 2 * pawn_push(us) == to)               // Not a double push
                && (double_step_region(us) & from)
-               && !(pieces() & (to | (to - pawn_push(us)))))
+               && !(occupied & (to | (to - pawn_push(us)))))
           && !(   (from + 3 * pawn_push(us) == to)               // Not a triple push
                && (triple_step_region(us) & from)
-               && !(pieces() & (to | (to - pawn_push(us)) | (to - 2 * pawn_push(us))))))
+               && !(occupied & (to | (to - pawn_push(us)) | (to - 2 * pawn_push(us))))))
           return false;
   }
   else if (!((capture(m) ? attacks_from(us, type_of(pc), from) : moves_from(us, type_of(pc), from)) & to))
@@ -1794,17 +1819,22 @@ bool Position::gives_check(Move m) const {
   Square to = to_sq(m);
 
   Bitboard freezeExtra = 0;
+  Bitboard freezeBlock = 0;
   Bitboard jumpRemoved = 0;
+  Variant::PotionType gatingPotion = Variant::POTION_TYPE_NB;
   if (is_gating(m))
   {
-      Variant::PotionType potion = potion_type_from_piece(var, gating_type(m));
-      if (potion != Variant::POTION_TYPE_NB)
+      gatingPotion = potion_type_from_piece(var, gating_type(m));
+      if (gatingPotion != Variant::POTION_TYPE_NB)
       {
-          if (!can_cast_potion(sideToMove, potion))
+          if (!can_cast_potion(sideToMove, gatingPotion))
               return false;
-          if (potion == Variant::POTION_FREEZE)
+          if (gatingPotion == Variant::POTION_FREEZE)
+          {
               freezeExtra = freeze_zone_from_square(gating_square(m));
-          else if (potion == Variant::POTION_JUMP)
+              freezeBlock = freeze_block_zone_from_square(gating_square(m));
+          }
+          else if (gatingPotion == Variant::POTION_JUMP)
           {
               jumpRemoved = square_bb(gating_square(m));
               if (!piece_on(gating_square(m)))
@@ -1815,6 +1845,9 @@ bool Position::gives_check(Move m) const {
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
+
+  if (gatingPotion == Variant::POTION_FREEZE && type_of(m) != DROP && (freezeBlock & from))
+      return false;
 
   Bitboard frozen = freeze_squares(sideToMove);
   if (type_of(m) != DROP && (frozen & from))
@@ -2568,8 +2601,18 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   st->key = k;
   // Calculate checkers bitboard (if move gives check)
   PieceType royal = royal_piece_type();
-  st->checkersBB = (givesCheck && count(them, royal)) ? attackers_to(square(them, royal), us) & pieces(us) : Bitboard(0);
-  assert(givesCheck == bool(st->checkersBB));
+  if (count(them, royal))
+  {
+      if (potions_enabled())
+          st->checkersBB = attackers_to(square(them, royal), us) & pieces(us);
+      else
+          st->checkersBB = givesCheck ? (attackers_to(square(them, royal), us) & pieces(us)) : Bitboard(0);
+  }
+  else
+      st->checkersBB = Bitboard(0);
+
+  if (!potions_enabled())
+      assert(givesCheck == bool(st->checkersBB));
 
   sideToMove = ~sideToMove;
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1757,7 +1757,7 @@ bool Position::pseudo_legal(const Move m) const {
   // Evasions generator already takes care to avoid some kind of illegal moves
   // and legal() relies on this. We therefore have to take care that the same
   // kind of moves are filtered out here.
-  if (checkers() && !(checkers() & non_sliding_riders()))
+  if (checkers() && !allow_self_check() && !(checkers() & non_sliding_riders()))
   {
       if (extinctionCapture)
           return true;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1319,7 +1319,8 @@ bool Position::legal(Move m) const {
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
   PieceType royal = royal_piece_type();
 
-  Bitboard frozen = freeze_move_squares();
+  Bitboard frozen = st->potionZones[WHITE][Variant::POTION_FREEZE]
+                  | st->potionZones[BLACK][Variant::POTION_FREEZE];
   if (type_of(m) != DROP && (frozen & from))
       return false;
   if (jumpRemoved && (square_bb(to) & jumpRemoved))
@@ -1522,7 +1523,7 @@ bool Position::legal(Move m) const {
       Square rto = to + (to_sq(m) > from_sq(m) ? WEST : EAST);
       if (is_gating(m) && (gating_square(m) == to || gating_square(m) == rto))  
           return false;
-      if (freeze_move_squares() & to_sq(m))
+      if (freeze_squares() & to_sq(m))
           return false;
 
       // Only the castling king piece is subject to attack checks

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -766,10 +766,11 @@ void Position::set_castling_right(Color c, Square rfrom) {
 
 void Position::set_check_info(StateInfo* si) const {
 
-  si->blockersForKing[WHITE] = slider_blockers(pieces(BLACK), count<KING>(WHITE) ? square<KING>(WHITE) : SQ_NONE, si->pinners[BLACK], BLACK);
-  si->blockersForKing[BLACK] = slider_blockers(pieces(WHITE), count<KING>(BLACK) ? square<KING>(BLACK) : SQ_NONE, si->pinners[WHITE], WHITE);
+  PieceType royal = royal_piece_type();
+  si->blockersForKing[WHITE] = slider_blockers(pieces(BLACK), count(WHITE, royal) ? square(WHITE, royal) : SQ_NONE, si->pinners[BLACK], BLACK);
+  si->blockersForKing[BLACK] = slider_blockers(pieces(WHITE), count(BLACK, royal) ? square(BLACK, royal) : SQ_NONE, si->pinners[WHITE], WHITE);
 
-  Square ksq = count<KING>(~sideToMove) ? square<KING>(~sideToMove) : SQ_NONE;
+  Square ksq = count(~sideToMove, royal) ? square(~sideToMove, royal) : SQ_NONE;
 
   // For unused piece types, the check squares are left uninitialized
   si->nonSlidingRiders = 0;
@@ -783,7 +784,7 @@ void Position::set_check_info(StateInfo* si) const {
           si->nonSlidingRiders |= pieces(pt);
   }
   si->shak = si->checkersBB & (byTypeBB[KNIGHT] | byTypeBB[ROOK] | byTypeBB[BERS]);
-  si->bikjang = var->bikjangRule && ksq != SQ_NONE ? bool(attacks_bb(sideToMove, ROOK, ksq, pieces()) & pieces(sideToMove, KING)) : false;
+  si->bikjang = var->bikjangRule && ksq != SQ_NONE ? bool(attacks_bb(sideToMove, ROOK, ksq, pieces()) & pieces(sideToMove, royal)) : false;
   si->chased = var->chasingRule ? chased() : Bitboard(0);
   si->legalCapture = NO_VALUE;
   if (var->extinctionPseudoRoyal)
@@ -813,7 +814,8 @@ void Position::set_state(StateInfo* si) const {
   si->key = si->materialKey = 0;
   si->pawnKey = Zobrist::noPawns;
   si->nonPawnMaterial[WHITE] = si->nonPawnMaterial[BLACK] = VALUE_ZERO;
-  si->checkersBB = count<KING>(sideToMove) ? attackers_to(square<KING>(sideToMove), ~sideToMove) : Bitboard(0);
+  PieceType royal = royal_piece_type();
+  si->checkersBB = count(sideToMove, royal) ? attackers_to(square(sideToMove, royal), ~sideToMove) : Bitboard(0);
   si->move = MOVE_NONE;
 
   set_check_info(si);
@@ -1310,6 +1312,7 @@ bool Position::legal(Move m) const {
   }
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
+  PieceType royal = royal_piece_type();
 
   if (type_of(m) != DROP && (freeze_squares() & from))
       return false;
@@ -1317,7 +1320,7 @@ bool Position::legal(Move m) const {
       return false;
 
   assert(color_of(moved_piece(m)) == us);
-  assert(!count<KING>(us) || piece_on(square<KING>(us)) == make_piece(us, KING));
+  assert(!count(us, royal) || piece_on(square(us, royal)) == make_piece(us, royal));
   assert(board_bb() & to);
 
   // Illegal checks
@@ -1488,9 +1491,9 @@ bool Position::legal(Move m) const {
   // En passant captures are a tricky special case. Because they are rather
   // uncommon, we do it simply by testing whether the king is attacked after
   // the move is made.
-  if (type_of(m) == EN_PASSANT && count<KING>(us))
+  if (type_of(m) == EN_PASSANT && count(us, royal))
   {
-      Square ksq = square<KING>(us);
+      Square ksq = square(us, royal);
       Square capsq = capture_square(to);
       Bitboard occupied = (pieces() ^ from ^ capsq) | to;
 
@@ -1522,7 +1525,7 @@ bool Position::legal(Move m) const {
 
       for (Square s = to; s != from; s += step)
           if (attackers_to(s, ~us)
-              || (var->flyingGeneral && (attacks_bb(~us, ROOK, s, pieces() ^ from) & pieces(~us, KING))))
+              || (var->flyingGeneral && (attacks_bb(~us, ROOK, s, pieces() ^ from) & pieces(~us, royal))))
               return false;
 
       // In case of Chess960, verify if the Rook blocks some checks
@@ -1536,24 +1539,24 @@ bool Position::legal(Move m) const {
   // In case of bikjang passing is always allowed, even when in check
   if (st->bikjang && is_pass(m))
       return true;
-  if ((var->flyingGeneral && count<KING>(us)) || st->bikjang)
+  if ((var->flyingGeneral && count(us, royal)) || st->bikjang)
   {
-      Square s = type_of(moved_piece(m)) == KING ? to : square<KING>(us);
-      if (attacks_bb(~us, ROOK, s, occupied) & pieces(~us, KING) & ~square_bb(to))
+      Square s = type_of(moved_piece(m)) == royal ? to : square(us, royal);
+      if (attacks_bb(~us, ROOK, s, occupied) & pieces(~us, royal) & ~square_bb(to))
           return false;
   }
 
   // Makpong rule
-  if (var->makpongRule && checkers() && type_of(moved_piece(m)) == KING && (checkers() ^ to))
+  if (var->makpongRule && checkers() && type_of(moved_piece(m)) == royal && (checkers() ^ to))
       return false;
 
   // If the moving piece is a king, check whether the destination square is
   // attacked by the opponent.
-  if (type_of(moved_piece(m)) == KING)
+  if (type_of(moved_piece(m)) == royal)
       return !attackers_to(to, occupied, ~us);
 
   // Return early when without king
-  if (!count<KING>(us))
+  if (!count(us, royal))
       return true;
 
   Bitboard janggiCannons = pieces(JANGGI_CANNON);
@@ -1563,7 +1566,7 @@ bool Position::legal(Move m) const {
       janggiCannons ^= to;
 
   // A non-king move is legal if the king is not under attack after the move.
-  return !(attackers_to(square<KING>(us), occupied, ~us, janggiCannons) & ~SquareBB[to]);
+  return !(attackers_to(square(us, royal), occupied, ~us, janggiCannons) & ~SquareBB[to]);
 }
 
 
@@ -1577,6 +1580,7 @@ bool Position::pseudo_legal(const Move m) const {
   Square from = from_sq(m);
   Square to = to_sq(m);
   Piece pc = moved_piece(m);
+  PieceType royal = royal_piece_type();
 
   // Illegal moves to squares outside of board or to wall squares
   if (!(board_bb() & to))
@@ -1673,7 +1677,7 @@ bool Position::pseudo_legal(const Move m) const {
           return false;
 
       // Friendly kings are never capturable, even when self-capture is enabled
-      if (type_of(piece_on(to)) == KING)
+      if (type_of(piece_on(to)) == royal)
           return false;
   }
 
@@ -1708,7 +1712,7 @@ bool Position::pseudo_legal(const Move m) const {
   // kind of moves are filtered out here.
   if (checkers() && !(checkers() & non_sliding_riders()))
   {
-      if (type_of(pc) != KING)
+      if (type_of(pc) != royal)
       {
           // Double check? In this case a king move is required
           if (more_than_one(checkers()))
@@ -1716,8 +1720,8 @@ bool Position::pseudo_legal(const Move m) const {
 
           // Our move must be a blocking evasion or a capture of the checking piece
           Square checksq = lsb(checkers());
-          if (  !(between_bb(square<KING>(us), lsb(checkers())) & to)
-              || ((LeaperAttacks[~us][type_of(piece_on(checksq))][checksq] & square<KING>(us)) && !(checkers() & to)))
+          if (  !(between_bb(square(us, royal), lsb(checkers())) & to)
+              || ((LeaperAttacks[~us][type_of(piece_on(checksq))][checksq] & square(us, royal)) && !(checkers() & to)))
               return false;
       }
       // In case of king moves under check we have to remove king so as to catch
@@ -1761,6 +1765,7 @@ bool Position::gives_check(Move m) const {
   }
 
   SpellContextScope spellScope(*this, freezeExtra, jumpRemoved);
+  PieceType royal = royal_piece_type();
 
   if (type_of(m) != DROP && (freeze_squares() & from))
       return false;
@@ -1768,7 +1773,7 @@ bool Position::gives_check(Move m) const {
       return false;
 
   // No check possible without king
-  if (!count<KING>(~sideToMove))
+  if (!count(~sideToMove, royal))
       return false;
 
   Bitboard occupied = (type_of(m) != DROP ? pieces() ^ from : pieces()) | to;
@@ -1785,12 +1790,12 @@ bool Position::gives_check(Move m) const {
       PieceType pt = type_of(moved_piece(m));
       if (pt == JANGGI_CANNON)
       {
-          if (attacks_bb(sideToMove, pt, to, occupied) & attacks_bb(sideToMove, pt, to, occupied & ~janggiCannons) & square<KING>(~sideToMove))
+          if (attacks_bb(sideToMove, pt, to, occupied) & attacks_bb(sideToMove, pt, to, occupied & ~janggiCannons) & square(~sideToMove, royal))
               return true;
       }
       else if (AttackRiderTypes[pt] & (HOPPING_RIDERS | ASYMMETRICAL_RIDERS))
       {
-          if (attacks_bb(sideToMove, pt, to, occupied) & square<KING>(~sideToMove))
+          if (attacks_bb(sideToMove, pt, to, occupied) & square(~sideToMove, royal))
               return true;
       }
       else if (check_squares(pt) & to)
@@ -1799,12 +1804,12 @@ bool Position::gives_check(Move m) const {
 
   // Is there a discovered check?
   if (  ((type_of(m) != DROP && (blockers_for_king(~sideToMove) & from)) || (non_sliding_riders() & pieces(sideToMove)))
-      && attackers_to(square<KING>(~sideToMove), occupied, sideToMove, janggiCannons) & occupied)
+      && attackers_to(square(~sideToMove, royal), occupied, sideToMove, janggiCannons) & occupied)
       return true;
 
   // Is there a check by gated pieces?
   if (    is_gating(m)
-      && attacks_bb(sideToMove, gating_type(m), gating_square(m), (pieces() ^ from) | to) & square<KING>(~sideToMove))
+      && attacks_bb(sideToMove, gating_type(m), gating_square(m), (pieces() ^ from) | to) & square(~sideToMove, royal))
       return true;
 
   // Petrified piece can't give check
@@ -1812,15 +1817,15 @@ bool Position::gives_check(Move m) const {
       return false;
 
   // Is there a check by special diagonal moves?
-  if (more_than_one(diagonal_lines() & (to | square<KING>(~sideToMove))))
+  if (more_than_one(diagonal_lines() & (to | square(~sideToMove, royal))))
   {
       PieceType pt = type_of(moved_piece(m));
       PieceType diagType = pt == WAZIR ? FERS : pt == SOLDIER ? PAWN : pt == ROOK ? BISHOP : NO_PIECE_TYPE;
-      if (diagType && (attacks_bb(sideToMove, diagType, to, occupied) & square<KING>(~sideToMove)))
+      if (diagType && (attacks_bb(sideToMove, diagType, to, occupied) & square(~sideToMove, royal)))
           return true;
       else if (pt == JANGGI_CANNON && (  rider_attacks_bb<RIDER_CANNON_DIAG>(to, occupied)
                                        & rider_attacks_bb<RIDER_CANNON_DIAG>(to, occupied & ~janggiCannons)
-                                       & square<KING>(~sideToMove)))
+                                       & square(~sideToMove, royal)))
           return true;
   }
 
@@ -1832,13 +1837,13 @@ bool Position::gives_check(Move m) const {
       return false;
 
   case PROMOTION:
-      return attacks_bb(sideToMove, promotion_type(m), to, pieces() ^ from) & square<KING>(~sideToMove);
+      return attacks_bb(sideToMove, promotion_type(m), to, pieces() ^ from) & square(~sideToMove, royal);
 
   case PIECE_PROMOTION:
-      return attacks_bb(sideToMove, promoted_piece_type(type_of(moved_piece(m))), to, pieces() ^ from) & square<KING>(~sideToMove);
+      return attacks_bb(sideToMove, promoted_piece_type(type_of(moved_piece(m))), to, pieces() ^ from) & square(~sideToMove, royal);
 
   case PIECE_DEMOTION:
-      return attacks_bb(sideToMove, type_of(unpromoted_piece_on(from)), to, pieces() ^ from) & square<KING>(~sideToMove);
+      return attacks_bb(sideToMove, type_of(unpromoted_piece_on(from)), to, pieces() ^ from) & square(~sideToMove, royal);
 
   // En passant capture with check? We have already handled the case
   // of direct checks and ordinary discovered check, so the only case we
@@ -1849,7 +1854,7 @@ bool Position::gives_check(Move m) const {
       Square capsq = capture_square(to);
       Bitboard b = (pieces() ^ from ^ capsq) | to;
 
-      return attackers_to(square<KING>(~sideToMove), b) & pieces(sideToMove) & b;
+      return attackers_to(square(~sideToMove, royal), b) & pieces(sideToMove) & b;
   }
   default: //CASTLING
   {
@@ -1862,11 +1867,11 @@ bool Position::gives_check(Move m) const {
       // Is there a discovered check?
       if (   castling_rank(WHITE) > RANK_1
           && ((blockers_for_king(~sideToMove) & rfrom) || (non_sliding_riders() & pieces(sideToMove)))
-          && attackers_to(square<KING>(~sideToMove), (pieces() ^ kfrom ^ rfrom) | rto | kto, sideToMove))
+          && attackers_to(square(~sideToMove, royal), (pieces() ^ kfrom ^ rfrom) | rto | kto, sideToMove))
           return true;
 
-      return   (PseudoAttacks[sideToMove][type_of(piece_on(rfrom))][rto] & square<KING>(~sideToMove))
-            && (attacks_bb(sideToMove, type_of(piece_on(rfrom)), rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & square<KING>(~sideToMove));
+      return   (PseudoAttacks[sideToMove][type_of(piece_on(rfrom))][rto] & square(~sideToMove, royal))
+            && (attacks_bb(sideToMove, type_of(piece_on(rfrom)), rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & square(~sideToMove, royal));
   }
   }
 }
@@ -2503,7 +2508,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Update the key with the final value
   st->key = k;
   // Calculate checkers bitboard (if move gives check)
-  st->checkersBB = givesCheck ? attackers_to(square<KING>(them), us) & pieces(us) : Bitboard(0);
+  PieceType royal = royal_piece_type();
+  st->checkersBB = (givesCheck && count(them, royal)) ? attackers_to(square(them, royal), us) & pieces(us) : Bitboard(0);
   assert(givesCheck == bool(st->checkersBB));
 
   sideToMove = ~sideToMove;

--- a/src/position.h
+++ b/src/position.h
@@ -178,6 +178,7 @@ public:
   bool fast_attacks() const;
   bool fast_attacks2() const;
   bool checking_permitted() const;
+  bool allow_self_check() const;
   bool drop_checks() const;
   bool self_capture() const;
   bool must_capture() const;
@@ -1174,6 +1175,13 @@ inline int Position::extinction_opponent_piece_count() const {
 inline bool Position::extinction_pseudo_royal() const {
   assert(var != nullptr);
   return var->extinctionPseudoRoyal;
+}
+
+inline bool Position::allow_self_check() const {
+  PieceType royal = royal_piece_type();
+  return   extinction_value() != VALUE_NONE
+        && (extinction_piece_types() & royal)
+        && !extinction_pseudo_royal();
 }
 
 inline PieceType Position::flag_piece(Color c) const {

--- a/src/position.h
+++ b/src/position.h
@@ -205,7 +205,6 @@ public:
   int potion_cooldown(Color c, Variant::PotionType type) const;
   Bitboard freeze_squares() const;
   Bitboard freeze_squares(Color c) const;
-  Bitboard frozen_squares(Color c) const;
   Bitboard jump_squares(Color c) const;
   Bitboard freeze_zone_from_square(Square s) const;
   bool gating() const;
@@ -957,17 +956,13 @@ inline bool Position::can_cast_potion(Color c, Variant::PotionType type) const {
 
 inline Bitboard Position::freeze_squares(Color c) const {
   Bitboard mask = st->potionZones[c][Variant::POTION_FREEZE];
-  if (spellContextActive && c == sideToMove)
+  if (spellContextActive)
       mask |= spellExtraFrozen;
   return mask;
 }
 
 inline Bitboard Position::freeze_squares() const {
   return freeze_squares(WHITE) | freeze_squares(BLACK);
-}
-
-inline Bitboard Position::frozen_squares(Color c) const {
-  return freeze_squares(~c);
 }
 
 inline Bitboard Position::jump_squares(Color c) const {

--- a/src/position.h
+++ b/src/position.h
@@ -162,11 +162,13 @@ public:
   PieceType king_type() const;
   PieceType nnue_king() const;
   Square nnue_king_square(Color c) const;
-  bool nnue_use_pockets() const;
-  bool nnue_applicable() const;
-  int nnue_piece_square_index(Color perspective, Piece pc) const;
-  int nnue_piece_hand_index(Color perspective, Piece pc) const;
-  int nnue_king_square_index(Square ksq) const;
+    bool nnue_use_pockets() const;
+    bool nnue_applicable() const;
+    int nnue_piece_square_index(Color perspective, Piece pc) const;
+    int nnue_piece_hand_index(Color perspective, Piece pc) const;
+    int nnue_king_square_index(Square ksq) const;
+    int nnue_potion_zone_index_base() const;
+    int nnue_potion_cooldown_index_base() const;
   bool free_drops() const;
   void set_spell_context(Bitboard freezeExtra, Bitboard jumpRemoved) const;
   void clear_spell_context() const;
@@ -657,10 +659,20 @@ inline int Position::nnue_piece_hand_index(Color perspective, Piece pc) const {
   return var->pieceHandIndex[perspective][pc];
 }
 
-inline int Position::nnue_king_square_index(Square ksq) const {
-  assert(var != nullptr);
-  return var->kingSquareIndex[ksq];
-}
+  inline int Position::nnue_king_square_index(Square ksq) const {
+    assert(var != nullptr);
+    return var->kingSquareIndex[ksq];
+  }
+
+  inline int Position::nnue_potion_zone_index_base() const {
+    assert(var != nullptr);
+    return var->nnuePotionZoneIndexBase;
+  }
+
+  inline int Position::nnue_potion_cooldown_index_base() const {
+    assert(var != nullptr);
+    return var->nnuePotionCooldownIndexBase;
+  }
 
 inline bool Position::checking_permitted() const {
   assert(var != nullptr);

--- a/src/position.h
+++ b/src/position.h
@@ -208,6 +208,7 @@ public:
   Bitboard freeze_squares(Color c) const;
   Bitboard jump_squares(Color c) const;
   Bitboard freeze_zone_from_square(Square s) const;
+  Bitboard freeze_block_zone_from_square(Square s) const;
   bool gating() const;
   bool walling() const;
   WallingRule walling_rule() const;
@@ -968,14 +969,22 @@ inline Bitboard Position::freeze_squares() const {
 }
 
 inline Bitboard Position::jump_squares(Color c) const {
-  Bitboard mask = st->potionZones[c][Variant::POTION_JUMP];
-  if (spellContextActive && c == sideToMove)
+  (void)c;
+  Bitboard mask = st->potionZones[WHITE][Variant::POTION_JUMP]
+                | st->potionZones[BLACK][Variant::POTION_JUMP];
+  if (spellContextActive)
       mask |= spellJumpRemoved;
   return mask;
 }
 
 inline Bitboard Position::freeze_zone_from_square(Square s) const {
   return (PseudoAttacks[WHITE][KING][s] | square_bb(s)) & board_bb();
+}
+
+inline Bitboard Position::freeze_block_zone_from_square(Square s) const {
+  Bitboard zone = square_bb(s);
+  zone |= shift<NORTH>(zone) | shift<SOUTH>(zone) | shift<EAST>(zone) | shift<WEST>(zone);
+  return zone & board_bb();
 }
 
 inline bool Position::gating() const {
@@ -1430,8 +1439,8 @@ inline Square Position::castling_rook_square(CastlingRights cr) const {
 
 inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s) const {
   Bitboard occupancy = byTypeBB[ALL_PIECES];
-  if (spellContextActive && c == sideToMove)
-      occupancy &= ~spellJumpRemoved;
+  if (potions_enabled())
+      occupancy &= ~jump_squares(c);
 
   if (var->fastAttacks || var->fastAttacks2)
       return attacks_bb(c, pt, s, occupancy) & board_bb();
@@ -1464,8 +1473,8 @@ inline Bitboard Position::attacks_from(Color c, PieceType pt, Square s) const {
 
 inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
   Bitboard occupancy = byTypeBB[ALL_PIECES];
-  if (spellContextActive && c == sideToMove)
-      occupancy &= ~spellJumpRemoved;
+  if (potions_enabled())
+      occupancy &= ~jump_squares(c);
 
   if (var->fastAttacks || var->fastAttacks2)
       return moves_bb(c, pt, s, occupancy) & board_bb();

--- a/src/position.h
+++ b/src/position.h
@@ -205,6 +205,7 @@ public:
   int potion_cooldown(Color c, Variant::PotionType type) const;
   Bitboard freeze_squares() const;
   Bitboard freeze_squares(Color c) const;
+  Bitboard freeze_move_squares() const;
   Bitboard jump_squares(Color c) const;
   Bitboard freeze_zone_from_square(Square s) const;
   bool gating() const;
@@ -961,9 +962,50 @@ inline Bitboard Position::freeze_squares(Color c) const {
   return mask;
 }
 
-inline Bitboard Position::freeze_squares() const {
-  return freeze_squares(WHITE) | freeze_squares(BLACK);
-}
+  inline Bitboard Position::freeze_squares() const {
+    return freeze_squares(WHITE) | freeze_squares(BLACK);
+  }
+
+  inline Bitboard Position::freeze_move_squares() const {
+    Bitboard centers = 0;
+    for (Color c : {WHITE, BLACK})
+    {
+      Bitboard zone = st->potionZones[c][Variant::POTION_FREEZE];
+      if (zone)
+      {
+        Square center = SQ_NONE;
+        Bitboard candidates = zone;
+        while (candidates)
+        {
+          Square s = pop_lsb(candidates);
+          if (freeze_zone_from_square(s) == zone)
+          {
+            center = s;
+            break;
+          }
+        }
+        if (center != SQ_NONE)
+          centers |= square_bb(center);
+      }
+    }
+    if (spellContextActive && spellExtraFrozen)
+    {
+      Square center = SQ_NONE;
+      Bitboard candidates = spellExtraFrozen;
+      while (candidates)
+      {
+        Square s = pop_lsb(candidates);
+        if (freeze_zone_from_square(s) == spellExtraFrozen)
+        {
+          center = s;
+          break;
+        }
+      }
+      if (center != SQ_NONE)
+        centers |= square_bb(center);
+    }
+    return centers;
+  }
 
 inline Bitboard Position::jump_squares(Color c) const {
   Bitboard mask = st->potionZones[c][Variant::POTION_JUMP];

--- a/src/position.h
+++ b/src/position.h
@@ -160,6 +160,7 @@ public:
   PieceType castling_king_piece(Color c) const;
   PieceSet castling_rook_pieces(Color c) const;
   PieceType king_type() const;
+  PieceType royal_piece_type() const;
   PieceType nnue_king() const;
   Square nnue_king_square(Color c) const;
     bool nnue_use_pockets() const;
@@ -628,6 +629,11 @@ inline PieceSet Position::castling_rook_pieces(Color c) const {
 inline PieceType Position::king_type() const {
   assert(var != nullptr);
   return var->kingType;
+}
+
+inline PieceType Position::royal_piece_type() const {
+  assert(var != nullptr);
+  return var->royalPiece;
 }
 
 inline PieceType Position::nnue_king() const {

--- a/src/position.h
+++ b/src/position.h
@@ -205,6 +205,7 @@ public:
   int potion_cooldown(Color c, Variant::PotionType type) const;
   Bitboard freeze_squares() const;
   Bitboard freeze_squares(Color c) const;
+  Bitboard frozen_squares(Color c) const;
   Bitboard jump_squares(Color c) const;
   Bitboard freeze_zone_from_square(Square s) const;
   bool gating() const;
@@ -956,13 +957,17 @@ inline bool Position::can_cast_potion(Color c, Variant::PotionType type) const {
 
 inline Bitboard Position::freeze_squares(Color c) const {
   Bitboard mask = st->potionZones[c][Variant::POTION_FREEZE];
-  if (spellContextActive)
+  if (spellContextActive && c == sideToMove)
       mask |= spellExtraFrozen;
   return mask;
 }
 
 inline Bitboard Position::freeze_squares() const {
   return freeze_squares(WHITE) | freeze_squares(BLACK);
+}
+
+inline Bitboard Position::frozen_squares(Color c) const {
+  return freeze_squares(~c);
 }
 
 inline Bitboard Position::jump_squares(Color c) const {

--- a/src/position.h
+++ b/src/position.h
@@ -956,8 +956,9 @@ inline bool Position::can_cast_potion(Color c, Variant::PotionType type) const {
 }
 
 inline Bitboard Position::freeze_squares(Color c) const {
-  Bitboard mask = st->potionZones[c][Variant::POTION_FREEZE];
-  if (spellContextActive)
+  // Freeze zones affect the opponent only; map to squares frozen for color c.
+  Bitboard mask = st->potionZones[~c][Variant::POTION_FREEZE];
+  if (spellContextActive && c == ~sideToMove)
       mask |= spellExtraFrozen;
   return mask;
 }

--- a/src/position.h
+++ b/src/position.h
@@ -205,7 +205,6 @@ public:
   int potion_cooldown(Color c, Variant::PotionType type) const;
   Bitboard freeze_squares() const;
   Bitboard freeze_squares(Color c) const;
-  Bitboard freeze_move_squares() const;
   Bitboard jump_squares(Color c) const;
   Bitboard freeze_zone_from_square(Square s) const;
   bool gating() const;
@@ -962,50 +961,9 @@ inline Bitboard Position::freeze_squares(Color c) const {
   return mask;
 }
 
-  inline Bitboard Position::freeze_squares() const {
-    return freeze_squares(WHITE) | freeze_squares(BLACK);
-  }
-
-  inline Bitboard Position::freeze_move_squares() const {
-    Bitboard centers = 0;
-    for (Color c : {WHITE, BLACK})
-    {
-      Bitboard zone = st->potionZones[c][Variant::POTION_FREEZE];
-      if (zone)
-      {
-        Square center = SQ_NONE;
-        Bitboard candidates = zone;
-        while (candidates)
-        {
-          Square s = pop_lsb(candidates);
-          if (freeze_zone_from_square(s) == zone)
-          {
-            center = s;
-            break;
-          }
-        }
-        if (center != SQ_NONE)
-          centers |= square_bb(center);
-      }
-    }
-    if (spellContextActive && spellExtraFrozen)
-    {
-      Square center = SQ_NONE;
-      Bitboard candidates = spellExtraFrozen;
-      while (candidates)
-      {
-        Square s = pop_lsb(candidates);
-        if (freeze_zone_from_square(s) == spellExtraFrozen)
-        {
-          center = s;
-          break;
-        }
-      }
-      if (center != SQ_NONE)
-        centers |= square_bb(center);
-    }
-    return centers;
-  }
+inline Bitboard Position::freeze_squares() const {
+  return freeze_squares(WHITE) | freeze_squares(BLACK);
+}
 
 inline Bitboard Position::jump_squares(Color c) const {
   Bitboard mask = st->potionZones[c][Variant::POTION_JUMP];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -101,7 +101,7 @@ namespace {
     return potion_type_from_gating_piece(pos, gating_type(m)) != Variant::POTION_TYPE_NB;
   }
 
-  bool is_tactical_potion(const Position& pos, Move m, Bitboard ourRoyalAttackers, Square enemyRoyal) {
+  bool is_tactical_potion(const Position& pos, Move m, Bitboard ourRoyalAttackers, Square enemyRoyal, Square ourRoyal) {
 
     if (!pos.potions_enabled() || !is_gating(m))
         return false;
@@ -110,11 +110,34 @@ namespace {
     if (potion != Variant::POTION_FREEZE)
         return false;
 
+    Color us = pos.side_to_move();
+    Color them = ~us;
     Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
     if (enemyRoyal != SQ_NONE && (zone & square_bb(enemyRoyal)))
         return true;
 
-    return ourRoyalAttackers && (zone & ourRoyalAttackers);
+    if (ourRoyal == SQ_NONE)
+        return false;
+
+    if (ourRoyalAttackers && (zone & ourRoyalAttackers))
+        return true;
+
+    Bitboard candidates = zone & pos.pieces(them);
+    if (!candidates)
+        return false;
+
+    Bitboard occ = pos.pieces();
+    while (candidates)
+    {
+        Square s = pop_lsb(candidates);
+        PieceType pt = type_of(pos.piece_on(s));
+        if (pt == NO_PIECE_TYPE)
+            continue;
+        if (attacks_bb(them, pt, s, occ) & square_bb(ourRoyal))
+            return true;
+    }
+
+    return false;
   }
 
   // Add a small random component to draw evaluations to avoid 3-fold blindness 
@@ -735,11 +758,15 @@ namespace {
     maxValue           = VALUE_INFINITE;
     Bitboard ourRoyalAttackers = 0;
     Square enemyRoyal = SQ_NONE;
+    Square ourRoyal = SQ_NONE;
     if (pos.potions_enabled())
     {
         PieceType royal = pos.royal_piece_type();
         if (pos.count(us, royal))
-            ourRoyalAttackers = pos.attackers_to(pos.square(us, royal), ~us);
+        {
+            ourRoyal = pos.square(us, royal);
+            ourRoyalAttackers = pos.attackers_to(ourRoyal, ~us);
+        }
         if (pos.count(~us, royal))
             enemyRoyal = pos.square(~us, royal);
     }
@@ -1176,7 +1203,7 @@ moves_loop: // When in check, search starts from here
       captureOrPromotion = pos.capture_or_promotion(move);
       movedPiece = pos.moved_piece(move);
       givesCheck = pos.gives_check(move);
-      const bool tacticalPotion = is_tactical_potion(pos, move, ourRoyalAttackers, enemyRoyal);
+      const bool tacticalPotion = is_tactical_potion(pos, move, ourRoyalAttackers, enemyRoyal, ourRoyal);
 
       // Calculate new depth for this move
       newDepth = depth - 1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,7 +83,20 @@ namespace {
     return d > 14 ? 73 : 6 * d * d + 229 * d - 215;
   }
 
-  // Add a small random component to draw evaluations to avoid 3-fold blindness
+  bool is_potion_gating_move(const Position& pos, Move m) {
+
+    if (!pos.potions_enabled() || !is_gating(m))
+        return false;
+
+    PieceType gatingPiece = gating_type(m);
+    for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+        if (pos.potion_piece(static_cast<Variant::PotionType>(idx)) == gatingPiece)
+            return true;
+
+    return false;
+  }
+
+  // Add a small random component to draw evaluations to avoid 3-fold blindness 
   Value value_draw(Thread* thisThread) {
     return VALUE_DRAW + Value(2 * (thisThread->nodes & 1) - 1);
   }
@@ -1134,6 +1147,8 @@ moves_loop: // When in check, search starts from here
 
       // Calculate new depth for this move
       newDepth = depth - 1;
+      if (is_potion_gating_move(pos, move) && depth >= 3)
+          newDepth = std::max(newDepth - (givesCheck || captureOrPromotion ? 1 : 2), 0);
 
       // Step 13. Pruning at shallow depth (~200 Elo)
       if (  !rootNode

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,17 +83,38 @@ namespace {
     return d > 14 ? 73 : 6 * d * d + 229 * d - 215;
   }
 
+  Variant::PotionType potion_type_from_gating_piece(const Position& pos, PieceType gatingPiece) {
+    for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+    {
+        auto potion = static_cast<Variant::PotionType>(idx);
+        if (pos.potion_piece(potion) == gatingPiece)
+            return potion;
+    }
+    return Variant::POTION_TYPE_NB;
+  }
+
   bool is_potion_gating_move(const Position& pos, Move m) {
 
     if (!pos.potions_enabled() || !is_gating(m))
         return false;
 
-    PieceType gatingPiece = gating_type(m);
-    for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
-        if (pos.potion_piece(static_cast<Variant::PotionType>(idx)) == gatingPiece)
-            return true;
+    return potion_type_from_gating_piece(pos, gating_type(m)) != Variant::POTION_TYPE_NB;
+  }
 
-    return false;
+  bool is_tactical_potion(const Position& pos, Move m, Bitboard ourRoyalAttackers, Square enemyRoyal) {
+
+    if (!pos.potions_enabled() || !is_gating(m))
+        return false;
+
+    Variant::PotionType potion = potion_type_from_gating_piece(pos, gating_type(m));
+    if (potion != Variant::POTION_FREEZE)
+        return false;
+
+    Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
+    if (enemyRoyal != SQ_NONE && (zone & square_bb(enemyRoyal)))
+        return true;
+
+    return ourRoyalAttackers && (zone & ourRoyalAttackers);
   }
 
   // Add a small random component to draw evaluations to avoid 3-fold blindness 
@@ -712,6 +733,16 @@ namespace {
     moveCount          = captureCount = quietCount = ss->moveCount = 0;
     bestValue          = -VALUE_INFINITE;
     maxValue           = VALUE_INFINITE;
+    Bitboard ourRoyalAttackers = 0;
+    Square enemyRoyal = SQ_NONE;
+    if (pos.potions_enabled())
+    {
+        PieceType royal = pos.royal_piece_type();
+        if (pos.count(us, royal))
+            ourRoyalAttackers = pos.attackers_to(pos.square(us, royal), ~us);
+        if (pos.count(~us, royal))
+            enemyRoyal = pos.square(~us, royal);
+    }
 
     // Check for the available remaining time
     if (thisThread == Threads.main())
@@ -1145,11 +1176,12 @@ moves_loop: // When in check, search starts from here
       captureOrPromotion = pos.capture_or_promotion(move);
       movedPiece = pos.moved_piece(move);
       givesCheck = pos.gives_check(move);
+      const bool tacticalPotion = is_tactical_potion(pos, move, ourRoyalAttackers, enemyRoyal);
 
       // Calculate new depth for this move
       newDepth = depth - 1;
       if (is_potion_gating_move(pos, move) && depth >= 3)
-          newDepth = std::max(newDepth - (givesCheck || captureOrPromotion ? 1 : 2), 0);
+          newDepth = std::max(newDepth - (givesCheck || captureOrPromotion || tacticalPotion ? 1 : 2), 0);
 
       // Step 13. Pruning at shallow depth (~200 Elo)
       if (  !rootNode
@@ -1167,10 +1199,12 @@ moves_loop: // When in check, search starts from here
           {}
           else
           if (   captureOrPromotion
-              || givesCheck)
+              || givesCheck
+              || tacticalPotion)
           {
               // Capture history based pruning when the move doesn't give check
               if (   !givesCheck
+                  && !tacticalPotion
                   && lmrDepth < 1
                   && captureHistory[movedPiece][to_sq(move)][type_of(pos.piece_on(to_sq(move)))] < 0)
                   continue;
@@ -1179,7 +1213,7 @@ moves_loop: // When in check, search starts from here
               if (!pos.see_ge(move, Value(-218 - 120 * pos.captures_to_hand()) * depth)) // (~25 Elo)
                   continue;
           }
-          else
+          else if (!tacticalPotion)
           {
               // Continuation history based pruning (~20 Elo)
               if (   lmrDepth < 5
@@ -1262,7 +1296,7 @@ moves_loop: // When in check, search starts from here
                   return beta;
           }
       }
-      else if (   givesCheck
+      else if (   (givesCheck || tacticalPotion)
                && depth > 6
                && abs(ss->staticEval) > Value(100))
           extension = 1;
@@ -1330,9 +1364,9 @@ moves_loop: // When in check, search starts from here
 
           // Increase reduction for cut nodes (~3 Elo)
           if (cutNode)
-              r += 1 + !captureOrPromotion;
+              r += 1 + (!captureOrPromotion && !tacticalPotion);
 
-          if (!captureOrPromotion)
+          if (!captureOrPromotion && !tacticalPotion)
           {
               // Increase reduction if ttMove is a capture (~3 Elo)
               if (ttCapture)
@@ -1349,6 +1383,8 @@ moves_loop: // When in check, search starts from here
               if (!ss->inCheck)
                   r -= ss->statScore / (14721 - 4434 * pos.captures_to_hand());
           }
+          else if (tacticalPotion)
+              r -= 1;
 
           // In general we want to cap the LMR depth search at newDepth. But if
           // reductions are really negative and movecount is low, we allow this move

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -727,7 +727,7 @@ namespace {
 
     // Step 1. Initialize node
     Thread* thisThread = pos.this_thread();
-    ss->inCheck        = pos.checkers();
+    ss->inCheck        = pos.checkers() && !pos.allow_self_check();
     priorCapture       = pos.captured_piece();
     Color us           = pos.side_to_move();
     moveCount          = captureCount = quietCount = ss->moveCount = 0;
@@ -1591,7 +1591,7 @@ moves_loop: // When in check, search starts from here
 
     Thread* thisThread = pos.this_thread();
     bestMove = MOVE_NONE;
-    ss->inCheck = pos.checkers();
+    ss->inCheck = pos.checkers() && !pos.allow_self_check();
     moveCount = 0;
 
     Value gameResult;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -116,9 +116,6 @@ namespace {
     if (enemyRoyal != SQ_NONE && (zone & square_bb(enemyRoyal)))
         return true;
 
-    if (ourRoyal == SQ_NONE)
-        return false;
-
     if (ourRoyalAttackers && (zone & ourRoyalAttackers))
         return true;
 
@@ -126,14 +123,23 @@ namespace {
     if (!candidates)
         return false;
 
+    const Value majorThreshold = PieceValue[MG][make_piece(WHITE, ROOK)];
     Bitboard occ = pos.pieces();
     while (candidates)
     {
         Square s = pop_lsb(candidates);
-        PieceType pt = type_of(pos.piece_on(s));
+        Piece pc = pos.piece_on(s);
+        PieceType pt = type_of(pc);
         if (pt == NO_PIECE_TYPE)
             continue;
-        if (attacks_bb(them, pt, s, occ) & square_bb(ourRoyal))
+
+        // Freezing an attacked or major enemy piece is a tactical motif in spell-chess.
+        if (PieceValue[MG][pc] >= majorThreshold)
+            return true;
+        if (pos.attackers_to(s, us))
+            return true;
+
+        if (ourRoyal != SQ_NONE && (attacks_bb(them, pt, s, occ) & square_bb(ourRoyal)))
             return true;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1165,7 +1165,6 @@ moves_loop: // When in check, search starts from here
           if (pos.must_capture() && pos.attackers_to(to_sq(move), ~us))
           {}
           else
-
           if (   captureOrPromotion
               || givesCheck)
           {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -936,6 +936,7 @@ namespace {
 
     // Step 7. Futility pruning: child node (~50 Elo)
     if (   !PvNode
+        && !ss->inCheck
         &&  depth < 9 - 3 * pos.blast_on_capture()
         &&  eval - futility_margin(depth, improving) * (1 + pos.check_counting() + 2 * pos.must_capture() + pos.extinction_single_piece() + !pos.checking_permitted()) >= beta
         &&  eval < VALUE_KNOWN_WIN) // Do not return unproven wins
@@ -943,6 +944,7 @@ namespace {
 
     // Step 8. Null move search with verification search (~40 Elo)
     if (   !PvNode
+        && !ss->inCheck
         && (ss-1)->currentMove != MOVE_NULL
         && (ss-1)->statScore < 23767
         &&  eval >= beta
@@ -1109,7 +1111,6 @@ moves_loop: // When in check, search starts from here
                          && ttMove
                          && (tte->bound() & BOUND_UPPER)
                          && tte->depth() >= depth;
-
     // Step 12. Loop through all pseudo-legal moves until no moves remain
     // or a beta cutoff occurs.
     while ((move = mp.next_move(moveCountPruning)) != MOVE_NONE)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1214,7 +1214,12 @@ moves_loop: // When in check, search starts from here
       // Calculate new depth for this move
       newDepth = depth - 1;
       if (is_potion_gating_move(pos, move) && depth >= 3)
-          newDepth = std::max(newDepth - (givesCheck || captureOrPromotion || tacticalPotion ? 1 : 2), 0);
+      {
+          int penalty = (givesCheck || captureOrPromotion || tacticalPotion) ? 1 : 2;
+          if (tacticalPotion)
+              penalty = 0; // Tactical potion moves behave like regular tactics.
+          newDepth = std::max(newDepth - penalty, 0);
+      }
 
       // Step 13. Pruning at shallow depth (~200 Elo)
       if (  !rootNode

--- a/src/tools/convert.cpp
+++ b/src/tools/convert.cpp
@@ -500,6 +500,213 @@ namespace Stockfish::Tools
         std::cout << "all done" << std::endl;
     }
 
+    struct PlainEntry {
+        std::string fen;
+        std::string move;
+        int score = 0;
+        int ply = 0;
+        int result = 0;
+        bool has_fen = false;
+        bool has_move = false;
+        bool has_score = false;
+        bool has_ply = false;
+        bool has_result = false;
+        void reset() {
+            fen.clear();
+            move.clear();
+            score = 0;
+            ply = 0;
+            result = 0;
+            has_fen = has_move = has_score = has_ply = has_result = false;
+        }
+    };
+
+    static inline std::string trim_left(std::string value)
+    {
+        const auto first = value.find_first_not_of(" \t");
+        if (first == std::string::npos)
+            return "";
+        value.erase(0, first);
+        return value;
+    }
+
+    static bool binpack_supported_variant(const Variant* v)
+    {
+        if (!v)
+            return false;
+        if (v->maxFile != FILE_H || v->maxRank != RANK_8)
+            return false;
+        if (v->pieceTypes != CHESS_PIECES)
+            return false;
+        if (v->pieceDrops || v->seirawanGating || v->gating || v->potions)
+            return false;
+        if (v->capturesToHand || v->twoBoards || v->wallingRule)
+            return false;
+        return true;
+    }
+
+    static bool use_engine_plain_converter()
+    {
+        auto it = variants.find(Options["UCI_Variant"]);
+        if (it == variants.end())
+            return true;
+        return !binpack_supported_variant(it->second);
+    }
+
+    static void convert_bin_to_plain_engine(std::string inputPath, std::string outputPath,
+                                            std::ios_base::openmode om, bool validate)
+    {
+        std::cout << "Converting " << inputPath << " to " << outputPath
+                  << " (engine format)\n";
+
+        std::ifstream inputFile(inputPath, std::ios_base::binary);
+        if (!inputFile)
+        {
+            std::cerr << "Input file does not exist.\n";
+            return;
+        }
+
+        std::ofstream outputFile(outputPath, om);
+        if (!outputFile)
+        {
+            std::cerr << "Output file could not be opened.\n";
+            return;
+        }
+
+        Position tpos;
+        StateInfo si;
+        auto th = Threads.main();
+        PackedSfenValue psv;
+        std::size_t numProcessedPositions = 0;
+
+        while (inputFile.read(reinterpret_cast<char*>(&psv), sizeof(psv)))
+        {
+            tpos.set_from_packed_sfen(psv.sfen, &si, th);
+            Move m = Move(psv.move);
+            if (validate && !tpos.legal(m))
+            {
+                std::cerr << "Illegal move " << UCI::move(tpos, m)
+                          << " for position " << tpos.fen() << '\n';
+                return;
+            }
+
+            outputFile << "fen " << tpos.fen() << '\n';
+            outputFile << "move " << UCI::move(tpos, m) << '\n';
+            outputFile << "score " << psv.score << '\n';
+            outputFile << "ply " << int(psv.gamePly) << '\n';
+            outputFile << "result " << int(psv.game_result) << '\n';
+            outputFile << "e\n";
+            ++numProcessedPositions;
+        }
+
+        std::cout << "Finished. Converted " << numProcessedPositions << " positions.\n";
+    }
+
+    static void convert_plain_to_bin_engine(std::string inputPath, std::string outputPath,
+                                            std::ios_base::openmode om, bool validate)
+    {
+        std::cout << "Converting " << inputPath << " to " << outputPath
+                  << " (engine format)\n";
+
+        std::ifstream inputFile(inputPath);
+        if (!inputFile)
+        {
+            std::cerr << "Input file does not exist.\n";
+            return;
+        }
+
+        std::ofstream outputFile(outputPath, std::ios_base::binary | om);
+        if (!outputFile)
+        {
+            std::cerr << "Output file could not be opened.\n";
+            return;
+        }
+
+        auto it = variants.find(Options["UCI_Variant"]);
+        const Variant* v = it == variants.end() ? nullptr : it->second;
+        Position pos;
+        StateInfo si;
+        auto th = Threads.main();
+
+        PlainEntry entry;
+        std::size_t numProcessedPositions = 0;
+        std::string key;
+        std::string value;
+
+        auto flush_entry = [&]() -> bool {
+            if (!entry.has_fen)
+                return true;
+
+            pos.set(v, entry.fen, false, &si, th);
+            std::string moveStr = entry.move;
+            Move m = UCI::to_move(pos, moveStr);
+            if (validate && (m == MOVE_NONE || !pos.legal(m)))
+            {
+                std::cerr << "Illegal move " << entry.move
+                          << " for position " << entry.fen << '\n';
+                return false;
+            }
+
+            PackedSfenValue psv{};
+            pos.sfen_pack(psv.sfen);
+            psv.score = static_cast<std::int16_t>(entry.score);
+            psv.move = static_cast<std::uint32_t>(m);
+            psv.gamePly = static_cast<std::uint16_t>(entry.ply);
+            psv.game_result = static_cast<std::int8_t>(entry.result);
+            psv.padding = 0;
+
+            outputFile.write(reinterpret_cast<const char*>(&psv), sizeof(psv));
+            ++numProcessedPositions;
+            entry.reset();
+            return true;
+        };
+
+        while (inputFile >> key)
+        {
+            if (key == "e")
+            {
+                if (!flush_entry())
+                    return;
+                continue;
+            }
+
+            inputFile >> std::ws;
+            std::getline(inputFile, value, '\n');
+            value = trim_left(value);
+
+            if (key == "fen")
+            {
+                entry.fen = value;
+                entry.has_fen = true;
+            }
+            else if (key == "move")
+            {
+                entry.move = value;
+                entry.has_move = true;
+            }
+            else if (key == "score")
+            {
+                entry.score = std::stoi(value);
+                entry.has_score = true;
+            }
+            else if (key == "ply")
+            {
+                entry.ply = std::stoi(value);
+                entry.has_ply = true;
+            }
+            else if (key == "result")
+            {
+                entry.result = std::stoi(value);
+                entry.has_result = true;
+            }
+        }
+
+        if (entry.has_fen)
+            flush_entry();
+
+        std::cout << "Finished. Converted " << numProcessedPositions << " positions.\n";
+    }
+
     static inline const std::string plain_extension = ".plain";
     static inline const std::string bin_extension = ".bin";
     static inline const std::string binpack_extension = ".binpack";
@@ -532,12 +739,12 @@ namespace Stockfish::Tools
     static ConvertFunctionType* get_convert_function(const std::string& input_path, const std::string& output_path)
     {
         if (is_convert_of_type(input_path, output_path, plain_extension, bin_extension))
-            return binpack::convertPlainToBin;
+            return use_engine_plain_converter() ? convert_plain_to_bin_engine : binpack::convertPlainToBin;
         if (is_convert_of_type(input_path, output_path, plain_extension, binpack_extension))
             return binpack::convertPlainToBinpack;
 
         if (is_convert_of_type(input_path, output_path, bin_extension, plain_extension))
-            return binpack::convertBinToPlain;
+            return use_engine_plain_converter() ? convert_bin_to_plain_engine : binpack::convertBinToPlain;
         if (is_convert_of_type(input_path, output_path, bin_extension, binpack_extension))
             return binpack::convertBinToBinpack;
 

--- a/src/tools/sfen_packer.cpp
+++ b/src/tools/sfen_packer.cpp
@@ -162,12 +162,38 @@ namespace Stockfish::Tools {
         {0b11111,5}, //
     };
 
-    inline Square to_variant_square(Square s, const Position& pos) {
-        return Square(s - rank_of(s) * (FILE_MAX - pos.max_file()));
+    inline Square to_variant_square(Square s, const Position& pos) {     
+        return Square(s - rank_of(s) * (FILE_MAX - pos.max_file()));     
+    }    
+
+    inline Square from_variant_square(Square s, const Position& pos) {   
+        return Square(s + s / pos.files() * (FILE_MAX - pos.max_file()));
     }
 
-    inline Square from_variant_square(Square s, const Position& pos) {
-        return Square(s + s / pos.files() * (FILE_MAX - pos.max_file()));
+    inline Square potion_zone_center(const Position& pos, Variant::PotionType potion,
+                                     Bitboard zone) {
+        if (!zone)
+            return SQ_NONE;
+        if (potion == Variant::POTION_FREEZE)
+        {
+            Bitboard candidates = zone;
+            while (candidates)
+            {
+                Square s = pop_lsb(candidates);
+                if (pos.freeze_zone_from_square(s) == zone)
+                    return s;
+            }
+        }
+        return lsb(zone);
+    }
+
+    inline Bitboard potion_zone_from_center(const Position& pos, Variant::PotionType potion,
+                                            Square s) {
+        if (s == SQ_NONE)
+            return Bitboard(0);
+        if (potion == Variant::POTION_FREEZE)
+            return pos.freeze_zone_from_square(s);
+        return square_bb(s);
     }
 
     // Pack sfen and store in data[64].
@@ -200,6 +226,27 @@ namespace Stockfish::Tools {
         for(auto c: Colors)
             for (PieceSet ps = pos.piece_types(); ps;)
                 stream.write_n_bit(pos.count_in_hand(c, pop_lsb(ps)), DATA_SIZE > 512 ? 7 : 5);
+
+        if (pos.potions_enabled())
+        {
+            for (auto c : Colors)
+                for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+                {
+                    Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+                    Bitboard zone = pos.potion_zone(c, potion);
+                    const bool has_zone = zone != Bitboard(0);
+                    Square center = has_zone ? potion_zone_center(pos, potion, zone) : SQ_NONE;
+                    stream.write_one_bit(has_zone ? 1 : 0);
+                    stream.write_n_bit(has_zone ? to_variant_square(center, pos) : 0, 7);
+                    int cooldown = pos.potion_cooldown(c, potion);
+                    if (cooldown < 0)
+                        cooldown = 0;
+                    const int maxCooldown = (1u << POTION_COOLDOWN_BITS) - 1;
+                    if (cooldown > maxCooldown)
+                        cooldown = maxCooldown;
+                    stream.write_n_bit(cooldown, POTION_COOLDOWN_BITS);
+                }
+        }
 
         // TODO(someone): Support chess960.
         stream.write_one_bit(pos.can_castle(WHITE_OO));
@@ -337,7 +384,7 @@ namespace Stockfish::Tools {
 
                 pos.put_piece(Piece(pc), sq);
 
-                if (stream.get_cursor()> 512)
+                if (stream.get_cursor()> DATA_SIZE)
                     return 1;
             }
         }
@@ -351,6 +398,25 @@ namespace Stockfish::Tools {
                 for (int i = 0; i < count; ++i)
                     pos.add_to_hand(make_piece(c, pt));
             }
+
+        if (pos.potions_enabled())
+        {
+            for (auto c : Colors)
+                for (int pt = 0; pt < Variant::POTION_TYPE_NB; ++pt)
+                {
+                    Variant::PotionType potion = static_cast<Variant::PotionType>(pt);
+                    const bool has_zone = stream.read_one_bit() != 0;
+                    Square center = SQ_NONE;
+                    if (has_zone)
+                        center = from_variant_square(Square(stream.read_n_bit(7)), pos);
+                    else
+                        stream.read_n_bit(7);
+                    const int cooldown = stream.read_n_bit(POTION_COOLDOWN_BITS);
+                    pos.st->potionCooldown[c][pt] = cooldown;
+                    pos.st->potionZones[c][pt] =
+                        has_zone ? potion_zone_from_center(pos, potion, center) : Bitboard(0);
+                }
+        }
 
         // Castling availability.
         // TODO(someone): Support chess960.

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 
 #include "types.h"
+#include "tune.h"
 #include "misc.h"
 #include "uci.h"
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -391,8 +391,9 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     std::cerr << "Writing config for variant " + variant << std::endl;
 
     const int nnuePieceTypes = popcount(v->pieceTypes) - (v->nnueKing != NO_PIECE_TYPE ? 1 : 0);
+    const int potionBits = v->potions ? COLOR_NB * Variant::POTION_TYPE_NB * (1 + 7 + POTION_COOLDOWN_BITS) : 0;
     const int dataSize = (v->maxFile + 1) * (v->maxRank + 1) + v->nnueMaxPieces * 5
-                        + nnuePieceTypes * 2 * 5 + 50 > 512 ? 1024 : 512;
+                        + nnuePieceTypes * 2 * 5 + 50 + potionBits > 512 ? 1024 : 512;
 
     if (dataSize > DATA_SIZE)
         std::cerr << std::endl << "Warning: Recommended training data size " << dataSize
@@ -410,7 +411,8 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     << "#define PIECE_COUNT " << v->nnueMaxPieces << std::endl
     << "#define POCKETS " << (v->nnueUsePockets ? "true" : "false") << std::endl
     << "#define KING_SQUARES " << v->nnueKingSquare << std::endl
-    << "#define DATA_SIZE " << DATA_SIZE << std::endl;
+    << "#define DATA_SIZE " << DATA_SIZE << std::endl
+    << "#define HAS_POTIONS " << (v->potions ? "true" : "false") << std::endl;
 
     if (out1.is_open()) {
         out1.close();
@@ -427,8 +429,9 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     << "KING_SQUARES = " << v->nnueKingSquare << std::endl
     << "PIECE_TYPES = " << nnuePieceTypes << std::endl
     << "PIECES = 2 * PIECE_TYPES" << std::endl
-    << "USE_POCKETS = " << (v->nnueUsePockets ? "True" : "False") << std::endl
+    << "USE_POCKETS = " << (v->nnueUsePockets ? "True" : "False") << std::endl  
     << "POCKETS = 2 * FILES if USE_POCKETS else 0" << std::endl
+    << "HAS_POTIONS = " << (v->potions ? "True" : "False") << std::endl
     << std::endl
     << "PIECE_VALUES = {" << std::endl;
     for (PieceSet ps = v->pieceTypes; ps;)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -390,7 +390,8 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     const Variant* v = variants.find(variant)->second;
     std::cerr << "Writing config for variant " + variant << std::endl;
 
-    const int nnuePieceTypes = popcount(v->pieceTypes) - (v->nnueKing != NO_PIECE_TYPE ? 1 : 0);
+    const int pieceTypeCount = popcount(v->pieceTypes);
+    const int nnuePieceTypes = pieceTypeCount - (v->nnueKing != NO_PIECE_TYPE ? 1 : 0);
     const int potionBits = v->potions ? COLOR_NB * Variant::POTION_TYPE_NB * (1 + 7 + POTION_COOLDOWN_BITS) : 0;
     const int dataSize = (v->maxFile + 1) * (v->maxRank + 1) + v->nnueMaxPieces * 5
                         + nnuePieceTypes * 2 * 5 + 50 + potionBits > 512 ? 1024 : 512;
@@ -407,7 +408,7 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     *varianth
     << "#define FILES " << v->maxFile + 1 << std::endl
     << "#define RANKS " << v->maxRank + 1 << std::endl
-    << "#define PIECE_TYPES " << nnuePieceTypes << std::endl
+    << "#define PIECE_TYPES " << pieceTypeCount << std::endl
     << "#define PIECE_COUNT " << v->nnueMaxPieces << std::endl
     << "#define POCKETS " << (v->nnueUsePockets ? "true" : "false") << std::endl
     << "#define KING_SQUARES " << v->nnueKingSquare << std::endl
@@ -427,7 +428,7 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     << "FILES = " << v->maxFile + 1 << std::endl
     << "SQUARES = RANKS * FILES" << std::endl
     << "KING_SQUARES = " << v->nnueKingSquare << std::endl
-    << "PIECE_TYPES = " << nnuePieceTypes << std::endl
+    << "PIECE_TYPES = " << pieceTypeCount << std::endl
     << "PIECES = 2 * PIECE_TYPES" << std::endl
     << "USE_POCKETS = " << (v->nnueUsePockets ? "True" : "False") << std::endl  
     << "POCKETS = 2 * FILES if USE_POCKETS else 0" << std::endl

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -91,6 +91,7 @@ namespace {
         v->potionDropOnOccupied = true;
         v->remove_piece(KING);
         v->add_piece(COMMONER, 'k');
+        v->royalPiece = COMMONER;
         v->castlingKingPiece[WHITE] = v->castlingKingPiece[BLACK] = COMMONER;
         v->pieceToChar[make_piece(WHITE, CUSTOM_PIECE_1)] = 'F';
         v->pieceToChar[make_piece(BLACK, CUSTOM_PIECE_1)] = 'f';

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2292,4 +2292,11 @@ std::vector<std::string> VariantMap::get_keys() {
   return keys;
 }
 
+// Explicit instantiations keep linkers happy in builds that still reference
+// VariantPath parsing entry points.
+template void VariantMap::parse_istream<true>(std::istream&);
+template void VariantMap::parse_istream<false>(std::istream&);
+template void VariantMap::parse<true>(const std::string&);
+template void VariantMap::parse<false>(const std::string&);
+
 } // namespace Stockfish

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2072,6 +2072,13 @@ Variant* Variant::conclude() {
     int nnuePockets = nnueUsePockets ? 2 * int(maxFile + 1) : 0;
     int nnueNonDropPieceIndices = (2 * std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnueSquares;
     int nnuePieceIndices = nnueNonDropPieceIndices + 2 * (std::bitset<64>(pieceTypes).count() - (nnueKing != NO_PIECE_TYPE)) * nnuePockets;
+    bool nnueHasPotions = potions;
+    nnuePotionZoneIndexBase = nnueHasPotions ? nnuePieceIndices : -1;
+    if (nnueHasPotions)
+        nnuePieceIndices += nnueSquares * COLOR_NB * Variant::POTION_TYPE_NB;
+    nnuePotionCooldownIndexBase = nnueHasPotions ? nnuePieceIndices : -1;
+    if (nnueHasPotions)
+        nnuePieceIndices += COLOR_NB * Variant::POTION_TYPE_NB * POTION_COOLDOWN_BITS;
     int i = 0;
     for (PieceSet ps = pieceTypes; ps;)
     {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -2296,7 +2296,5 @@ std::vector<std::string> VariantMap::get_keys() {
 // VariantPath parsing entry points.
 template void VariantMap::parse_istream<true>(std::istream&);
 template void VariantMap::parse_istream<false>(std::istream&);
-template void VariantMap::parse<true>(const std::string&);
-template void VariantMap::parse<false>(const std::string&);
 
 } // namespace Stockfish

--- a/src/variant.h
+++ b/src/variant.h
@@ -89,6 +89,7 @@ struct Variant {
   PieceSet castlingRookPieces[COLOR_NB] = {piece_set(ROOK), piece_set(ROOK)};
   bool oppositeCastling = false;
   PieceType kingType = KING;
+  PieceType royalPiece = KING;
   bool checking = true;
   bool dropChecks = true;
   bool mustCapture = false;

--- a/src/variant.h
+++ b/src/variant.h
@@ -186,6 +186,8 @@ struct Variant {
   int pieceIndex[PIECE_TYPE_NB];
   int nnueDimensions;
   bool nnueUsePockets;
+  int nnuePotionZoneIndexBase = -1;
+  int nnuePotionCooldownIndexBase = -1;
   int pieceSquareIndex[COLOR_NB][PIECE_NB];
   int pieceHandIndex[COLOR_NB][PIECE_NB];
   int kingSquareIndex[SQUARE_NB];

--- a/test.py
+++ b/test.py
@@ -1004,6 +1004,18 @@ class TestPyffish(unittest.TestCase):
         self.assertNotEqual(result, sf.VALUE_MATE)
         self.assertNotEqual(result, -sf.VALUE_MATE)
 
+    def test_spell_chess_freeze_mate_in_two_threat(self):
+        fen = "rnbqkb1r/pppppppp/8/1n2P3/8/8/PPPP1PPP/R1BQK1NR[JJFFFFFjjffff] {F@-:0,J@-:0,f@-:2,j@-:0} w KQkq - 0 5"
+        moves = sf.legal_moves("spell-chess", fen, [])
+        self.assertIn("f@g7,d1h5", moves)
+        result = sf.game_result("spell-chess", fen, ["f@g7,d1h5", "a7a6", "h5f7"])
+        self.assertGreaterEqual(result, sf.VALUE_MATE)
+
+    def test_spell_chess_jump_zone_expired_allows_capture(self):
+        fen = "2rqk2r/pp2nppp/8/1p2Q3/1P1nP3/3PBP2/PP3P1P/R3K2R[JFFFjjfff] {F@-:1,J@d4:2,f@-:0,j@-:0} w KQk - 1 14"
+        moves = sf.legal_moves("spell-chess", fen, [])
+        self.assertIn("e3d4", moves)
+
     def test_get_san(self):
         fen = "4k3/8/3R4/8/1R3R2/8/3R4/4K3 w - - 0 1"
         result = sf.get_san("chess", fen, "b4d4")

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -150,9 +150,9 @@ if [[ $1 == "all" || $1 == "variant" ]]; then
   expect perft.exp flipello startpos 7 55092 > /dev/null
   expect perft.exp flipersi startpos 9 38208 > /dev/null
   # 960 variants
-  expect perft.exp atomic "fen 8/8/8/8/8/8/2k5/rR4KR w KQ - 0 1" 4 61401 true > /dev/null
-  expect perft.exp atomic "fen r3k1rR/5K2/8/8/8/8/8/8 b kq - 0 1" 4 98729 true > /dev/null
-  expect perft.exp atomic "fen Rr2k1rR/3K4/3p4/8/8/8/7P/8 w kq - 0 1" 4 241478 true > /dev/null
+  expect perft.exp atomic "fen 8/8/8/8/8/8/2k5/rR4KR w KQ - 0 1" 4 56567 true > /dev/null
+  expect perft.exp atomic "fen r3k1rR/5K2/8/8/8/8/8/8 b kq - 0 1" 4 95154 true > /dev/null
+  expect perft.exp atomic "fen Rr2k1rR/3K4/3p4/8/8/8/7P/8 w kq - 0 1" 4 233278 true > /dev/null
   expect perft.exp atomic "fen 1R4kr/4K3/8/8/8/8/8/8 b k - 0 1" 4 17915 true > /dev/null
   expect perft.exp extinction "fen rnbqb1kr/pppppppp/8/8/8/8/PPPPPPPP/RNBQB1KR w AHah - 0 1" 4 195286 true > /dev/null
   expect perft.exp seirawan "fen qbbrnkrn/pppppppp/8/8/8/8/PPPPPPPP/QBBRNKRN[HEhe] w ABCDEFGHabcdefgh - 0 1" 3 21170 true > /dev/null

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -154,7 +154,7 @@ if [[ $1 == "all" || $1 == "variant" ]]; then
   expect perft.exp atomic "fen r3k1rR/5K2/8/8/8/8/8/8 b kq - 0 1" 4 95154 true > /dev/null
   expect perft.exp atomic "fen Rr2k1rR/3K4/3p4/8/8/8/7P/8 w kq - 0 1" 4 233278 true > /dev/null
   expect perft.exp atomic "fen 1R4kr/4K3/8/8/8/8/8/8 b k - 0 1" 4 17915 true > /dev/null
-  expect perft.exp extinction "fen rnbqb1kr/pppppppp/8/8/8/8/PPPPPPPP/RNBQB1KR w AHah - 0 1" 4 195286 true > /dev/null
+  expect perft.exp extinction "fen rnbqb1kr/pppppppp/8/8/8/8/PPPPPPPP/RNBQB1KR w AHah - 0 1" 4 195284 true > /dev/null
   expect perft.exp seirawan "fen qbbrnkrn/pppppppp/8/8/8/8/PPPPPPPP/QBBRNKRN[HEhe] w ABCDEFGHabcdefgh - 0 1" 3 21170 true > /dev/null
 fi
 


### PR DESCRIPTION
  - Emit HAS_POTIONS in trainer_config and include potion bit budget in DATA_SIZE recommendation.
  - Pack potion zone + cooldown bits into PackedSfen and preserve them across convert paths.
  - Mirror NNUE hash gating / HalfKAv2 changes so tool-side NNUE stays aligned.