### PR TITLE
VLB tools: wide PackedSFEN, move encoding, and trainer config for very large boards

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -1,13 +1,7 @@
 name: fairy
 on:
   push:
-    branches:
-      - master
-      - tools
   pull_request:
-    branches:
-      - master
-      - tools
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ master, tools ]
   pull_request:
-    branches: [ master, tools ]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -1,14 +1,7 @@
 name: Stockfish
 on:
   push:
-    branches:
-      - master
-      - tools
-      - github_ci
   pull_request:
-    branches:
-      - master
-      - tools
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/src/Makefile
+++ b/src/Makefile
@@ -108,6 +108,7 @@ VPATH = syzygy:nnue:nnue/features:eval:extra:tools
 
 ### 2.1. General and architecture defaults
 largeboards = no
+verylargeboards = no
 all = no
 precomputedmagics = yes
 nnue = no
@@ -350,6 +351,11 @@ CXXFLAGS += -Wno-profile-instr-out-of-date
 
 # Compile version with support for large board variants
 # Use precomputed magics by default if pext is not available
+ifneq ($(verylargeboards),no)
+	largeboards = yes
+	precomputedmagics = no
+	CXXFLAGS += -DVERY_LARGE_BOARDS
+endif
 ifneq ($(largeboards),no)
 	CXXFLAGS += -DLARGEBOARDS
 	ifeq ($(precomputedmagics),yes)
@@ -367,7 +373,11 @@ ifneq ($(all),no)
 	CXXFLAGS += -DALLVARS
 endif
 
-ifeq ($(largedata),yes)
+ifneq ($(datasize),)
+	CXXFLAGS += -DDATA_SIZE=$(datasize)
+else ifneq ($(verylargeboards),no)
+	CXXFLAGS += -DDATA_SIZE=2048
+else ifeq ($(largedata),yes)
 	CXXFLAGS += -DDATA_SIZE=1024
 else
 	CXXFLAGS += -DDATA_SIZE=512
@@ -799,9 +809,14 @@ else
 	@echo ""
 	@echo "make build ARCH=x86-64 COMP=gcc largeboards=yes"
 	@echo ""
+	@echo "Version for very large boards (up to 16x16): "
+	@echo ""
+	@echo "make build ARCH=x86-64 COMP=gcc verylargeboards=yes"
+	@echo ""
 	@echo "Include all variants (adds Game of the Amazons): "
 	@echo ""
 	@echo "make build ARCH=x86-64 largeboards=yes all=yes"
+	@echo "make build ARCH=x86-64 verylargeboards=yes all=yes"
 	@echo ""
 endif
 
@@ -924,6 +939,7 @@ config-sanity: $(load_net)
 	@echo ""
 	@echo "Fairy-Stockfish specific:"
 	@echo "largeboards: '$(largeboards)'"
+	@echo "verylargeboards: '$(verylargeboards)'"
 	@echo "all: '$(all)'"
 	@echo "precomputedmagics: '$(precomputedmagics)'"
 	@echo "nnue: '$(nnue)'"

--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -122,6 +122,12 @@ inline std::string piece(const Position& pos, Move m, Notation n) {
     Square from = from_sq(m);
     Piece pc = pos.moved_piece(m);
     PieceType pt = type_of(pc);
+    auto symbol_upper = [&](PieceType type) {
+        const std::string& syn = pos.piece_symbol_synonym(make_piece(WHITE, type));
+        if (!syn.empty())
+            return syn;
+        return pos.piece_symbol(make_piece(WHITE, type));
+    };
     // Quiet pawn moves
     if ((n == NOTATION_SAN || n == NOTATION_LAN || n == NOTATION_THAI_SAN) && type_of(pc) == PAWN && type_of(m) != DROP)
         return "";
@@ -130,16 +136,14 @@ inline std::string piece(const Position& pos, Move m, Notation n) {
         return std::to_string(popcount(forward_file_bb(us, from) & pos.pieces(us, pt)) + 1);
     // Moves of promoted pieces
     else if (is_shogi(n) && type_of(m) != DROP && pos.unpromoted_piece_on(from))
-        return "+" + std::string(1, toupper(pos.piece_to_char()[pos.unpromoted_piece_on(from)]));
+        return "+" + symbol_upper(type_of(pos.unpromoted_piece_on(from)));
     // Promoted drops
     else if (is_shogi(n) && type_of(m) == DROP && dropped_piece_type(m) != in_hand_piece_type(m))
-        return "+" + std::string(1, toupper(pos.piece_to_char()[in_hand_piece_type(m)]));
+        return "+" + symbol_upper(in_hand_piece_type(m));
     else if (is_thai(n))
         return piece_to_thai_char(pc, pos.is_promoted(from));
-    else if (pos.piece_to_char_synonyms()[pc] != ' ')
-        return std::string(1, toupper(pos.piece_to_char_synonyms()[pc]));
     else
-        return std::string(1, toupper(pos.piece_to_char()[pc]));
+        return symbol_upper(type_of(pc));
 }
 
 inline std::string file(const Position& pos, Square s, Notation n) {
@@ -293,8 +297,8 @@ inline const std::string move_to_san(Position& pos, Move m, Notation n) {
 
         if (is_gating(m))
         {
-            san += std::string("/") + (char)toupper(pos.piece_to_char()[make_piece(us, gating_type(m))]);
-            san += square(pos, gating_square(m), n);
+            san += std::string("/") + pos.piece_symbol(make_piece(WHITE, gating_type(m)));
+            san += square(pos, pos.gate_square(m), n);
         }
     }
     else
@@ -334,20 +338,20 @@ inline const std::string move_to_san(Position& pos, Move m, Notation n) {
 
         // Suffix
         if (type_of(m) == PROMOTION)
-            san += std::string("=") + (char)toupper(pos.piece_to_char()[make_piece(us, promotion_type(m))]);
+            san += std::string("=") + pos.piece_symbol(make_piece(WHITE, promotion_type(m)));
         else if (type_of(m) == PIECE_PROMOTION)
-            san += is_shogi(n) ? std::string("+") : std::string("=") + (char)toupper(pos.piece_to_char()[make_piece(us, pos.promoted_piece_type(type_of(pos.moved_piece(m))))]);
+            san += is_shogi(n) ? std::string("+") : std::string("=") + pos.piece_symbol(make_piece(WHITE, pos.promoted_piece_type(type_of(pos.moved_piece(m)))));
         else if (type_of(m) == PIECE_DEMOTION)
-            san += is_shogi(n) ? std::string("-") : std::string("=") + std::string(1, toupper(pos.piece_to_char()[pos.unpromoted_piece_on(from)]));
+            san += is_shogi(n) ? std::string("-") : std::string("=") + pos.piece_symbol(make_piece(WHITE, type_of(pos.unpromoted_piece_on(from))));
         else if (type_of(m) == NORMAL && is_shogi(n) && pos.pseudo_legal(make<PIECE_PROMOTION>(from, to)))
             san += std::string("=");
         if (is_gating(m))
-            san += std::string("/") + (char)toupper(pos.piece_to_char()[make_piece(us, gating_type(m))]);
+            san += std::string("/") + pos.piece_symbol(make_piece(WHITE, gating_type(m)));
     }
 
     // Wall square
     if (pos.walling())
-        san += "," + square(pos, gating_square(m), n);
+        san += "," + square(pos, pos.gate_square(m), n);
 
     // Check and checkmate
     if (pos.gives_check(m) && !is_shogi(n) && n != NOTATION_XIANGQI_WXF)
@@ -483,20 +487,20 @@ inline int non_root_euclidian_distance(const CharSquare& s1, const CharSquare& s
     return pow(s1.rowIdx - s2.rowIdx, 2) + pow(s1.fileIdx - s2.fileIdx, 2);
 }
 
-class CharBoard {
+class PieceBoard {
 private:
     int nbRanks;
     int nbFiles;
-    std::vector<char> board;  // fill an array where the pieces are for later geometry checks
+    std::vector<Piece> board;  // fill an array where the pieces are for later geometry checks
 public:
-    CharBoard(int ranks, int files) : nbRanks(ranks), nbFiles(files) {
+    PieceBoard(int ranks, int files) : nbRanks(ranks), nbFiles(files) {
         assert(nbFiles > 0 && nbRanks > 0);
-        board = std::vector<char>(nbRanks * nbFiles, ' ');
+        board = std::vector<Piece>(nbRanks * nbFiles, NO_PIECE);
     }
-    void set_piece(int rankIdx, int fileIdx, char c) {
-        board[rankIdx * nbFiles + fileIdx] = c;
+    void set_piece(int rankIdx, int fileIdx, Piece pc) {
+        board[rankIdx * nbFiles + fileIdx] = pc;
     }
-    char get_piece(int rowIdx, int fileIdx) const {
+    Piece get_piece(int rowIdx, int fileIdx) const {
         return board[rowIdx * nbFiles + fileIdx];
     }
     int get_nb_ranks() const {
@@ -506,7 +510,7 @@ public:
         return nbFiles;
     }
     /// Returns the square of a given character
-    CharSquare get_square_for_piece(char piece) const {
+    CharSquare get_square_for_piece(Piece piece) const {
         CharSquare s;
         for (int r = 0; r < nbRanks; ++r)
         {
@@ -523,23 +527,25 @@ public:
         return s;
     }
     /// Returns all square positions for a given piece
-    std::vector<CharSquare> get_squares_for_pieces(Color color, PieceSet ps, const std::string& pieceChars) const {
+    std::vector<CharSquare> get_squares_for_pieces(Color color, PieceSet ps) const {
         std::vector<CharSquare> squares;
-        size_t pcIdx;
         for (int r = 0; r < nbRanks; ++r)
             for (int c = 0; c < nbFiles; ++c)
-                if ((pcIdx = pieceChars.find(get_piece(r, c))) != std::string::npos && (ps & type_of(Piece(pcIdx))) && color_of(Piece(pcIdx)) == color)
+            {
+                Piece pc = get_piece(r, c);
+                if (pc != NO_PIECE && (ps & type_of(pc)) && color_of(pc) == color)
                     squares.emplace_back(CharSquare(r, c));
+            }
         return squares;
     }
-    friend std::ostream& operator<<(std::ostream& os, const CharBoard& board);
+    friend std::ostream& operator<<(std::ostream& os, const PieceBoard& board);
 };
 
-inline std::ostream& operator<<(std::ostream& os, const CharBoard& board) {
+inline std::ostream& operator<<(std::ostream& os, const PieceBoard& board) {
     for (int r = 0; r < board.nbRanks; ++r)
     {
         for (int c = 0; c < board.nbFiles; ++c)
-            os << "[" << board.get_piece(r, c) << "] ";
+            os << "[" << static_cast<int>(board.get_piece(r, c)) << "] ";
         os << std::endl;
     }
     return os;
@@ -557,13 +563,30 @@ inline bool in_any(const std::vector<std::string>& vec, char c) {
 }
 
 inline Validation check_for_valid_characters(const std::string& firstFenPart, const std::string& validSpecialCharactersFirstField, const Variant* v) {
-    for (char c : firstFenPart)
+    for (size_t i = 0; i < firstFenPart.size(); ++i)
     {
-        if (!isdigit(c) && !in_any({v->pieceToChar, v->pieceToCharSynonyms, validSpecialCharactersFirstField}, c))
+        char c = firstFenPart[i];
+        if (isdigit(c) || contains(validSpecialCharactersFirstField, c))
+            continue;
+        if (c == '+')
+            continue;
+        if (Variant::is_piece_id_start(c))
         {
-            std::cerr << "Invalid piece character: '" << c << "'." << std::endl;
-            return NOK;
+            std::string token(1, c);
+            if (i + 1 < firstFenPart.size() && Variant::is_piece_id_suffix(firstFenPart[i + 1]))
+            {
+                token.push_back(firstFenPart[i + 1]);
+                ++i;
+            }
+            if (v->piece_from_symbol(token) == NO_PIECE)
+            {
+                std::cerr << "Invalid piece token: '" << token << "'." << std::endl;
+                return NOK;
+            }
+            continue;
         }
+        std::cerr << "Invalid piece character: '" << c << "'." << std::endl;
+        return NOK;
     }
     return OK;
 }
@@ -573,37 +596,33 @@ inline Validation check_promoted_pieces(const std::string& firstFenPart, const V
     if (!v || !v->shogiStylePromotions)
         return OK;
     
-    for (size_t i = 0; i < firstFenPart.length() - 1; ++i) {
-        // Look for promoted pieces ('+' followed by piece character)
-        if (firstFenPart[i] == '+') {
-            char pieceChar = firstFenPart[i + 1];
-            
-            // Skip if next character is not a piece character or is a special character
-            if (isdigit(pieceChar) || pieceChar == '/' || pieceChar == ' ' || pieceChar == '[')
-                continue;
-                
-            // Find the piece type corresponding to this character
-            size_t idx = v->pieceToChar.find(pieceChar);
-            if (idx == std::string::npos) {
-                // Try synonyms
-                idx = v->pieceToCharSynonyms.find(pieceChar);
-                if (idx == std::string::npos)
-                    continue; // Character validation will catch this
-            }
-            
-            // Ensure idx is within valid range for piece types
-            if (idx >= PIECE_TYPE_NB)
-                continue;
-                
-            // Get the piece type directly from the index
-            PieceType pt = PieceType(idx);
-            
-            // Check if this piece type has a promoted form
-            if (pt != NO_PIECE_TYPE && pt < PIECE_TYPE_NB && v->promotedPieceType[pt] == NO_PIECE_TYPE) {
-                std::cerr << "Invalid promoted piece: '+' followed by '" << pieceChar 
-                         << "'. This piece cannot be promoted in variant." << std::endl;
-                return NOK;
-            }
+    for (size_t i = 0; i < firstFenPart.length(); ++i) {
+        if (firstFenPart[i] != '+')
+            continue;
+
+        if (i + 1 >= firstFenPart.size())
+            continue;
+
+        char pieceChar = firstFenPart[i + 1];
+        if (!Variant::is_piece_id_start(pieceChar))
+            continue;
+
+        std::string token(1, pieceChar);
+        if (i + 2 < firstFenPart.size() && Variant::is_piece_id_suffix(firstFenPart[i + 2]))
+        {
+            token.push_back(firstFenPart[i + 2]);
+            ++i;
+        }
+
+        PieceType pt = v->piece_type_from_symbol(token);
+        if (pt == NO_PIECE_TYPE)
+            continue;
+
+        if (v->promotedPieceType[pt] == NO_PIECE_TYPE)
+        {
+            std::cerr << "Invalid promoted piece: '+' followed by '" << token
+                      << "'. This piece cannot be promoted in variant." << std::endl;
+            return NOK;
         }
     }
     return OK;
@@ -619,25 +638,32 @@ inline std::vector<std::string> get_fen_parts(const std::string& fullFen, char d
 }
 
 /// fills the character board according to a given FEN string
-inline Validation fill_char_board(CharBoard& board, const std::string& fenBoard, const std::string& validSpecialCharactersFirstField, const Variant* v) {
+inline Validation fill_char_board(PieceBoard& board, const std::string& fenBoard, const std::string& validSpecialCharactersFirstField, const Variant* v) {
     int rankIdx = 0;
     int fileIdx = 0;
 
-    char prevChar = '?';
-    for (char c : fenBoard)
+    for (size_t i = 0; i < fenBoard.size(); ++i)
     {
+        char c = fenBoard[i];
         if (c == ' ' || c == '[')
             break;
         if (c == '*')
-            ++fileIdx;
-        else if (isdigit(c))
         {
-            fileIdx += c - '0';
-            // if we have multiple digits attached we can add multiples of 9 to compute the resulting number (e.g. -> 21 = 2 + 2 * 9 + 1)
-            if (isdigit(prevChar))
-                fileIdx += 9 * (prevChar - '0');
+            ++fileIdx;
+            continue;
         }
-        else if (c == '/')
+        if (isdigit(c))
+        {
+            int number = c - '0';
+            while (i + 1 < fenBoard.size() && isdigit(fenBoard[i + 1]))
+            {
+                ++i;
+                number = number * 10 + (fenBoard[i] - '0');
+            }
+            fileIdx += number;
+            continue;
+        }
+        if (c == '/')
         {
             ++rankIdx;
             if (fileIdx != board.get_nb_files())
@@ -648,18 +674,44 @@ inline Validation fill_char_board(CharBoard& board, const std::string& fenBoard,
             if (rankIdx == board.get_nb_ranks())
                 break;
             fileIdx = 0;
+            continue;
         }
-        else if (!contains(validSpecialCharactersFirstField, c))
-        {  // normal piece
+        if (c == '+')
+        {
+            if (i + 1 >= fenBoard.size())
+                return NOK;
+            c = fenBoard[++i];
+        }
+        if (Variant::is_piece_id_start(c))
+        {
+            std::string token(1, c);
+            if (i + 1 < fenBoard.size() && Variant::is_piece_id_suffix(fenBoard[i + 1]))
+            {
+                token.push_back(fenBoard[i + 1]);
+                ++i;
+            }
             if (fileIdx == board.get_nb_files())
             {
-                std::cerr << "File index: " << fileIdx << " for piece '" << c << "' exceeds maximum of allowed number of files: " << board.get_nb_files() << "." << std::endl;
+                std::cerr << "File index: " << fileIdx << " for piece '" << token << "' exceeds maximum of allowed number of files: " << board.get_nb_files() << "." << std::endl;
                 return NOK;
             }
-            board.set_piece(v->maxRank-rankIdx, fileIdx, c);  // we mirror the rank index because the black pieces are given first in the FEN
+            Piece pc = v->piece_from_symbol(token);
+            if (pc == NO_PIECE)
+            {
+                std::cerr << "Invalid piece token: '" << token << "'." << std::endl;
+                return NOK;
+            }
+            board.set_piece(v->maxRank - rankIdx, fileIdx, pc);  // mirror rank index
             ++fileIdx;
+            if (i + 1 < fenBoard.size() && fenBoard[i + 1] == '~')
+                ++i;
+            continue;
         }
-        prevChar = c;
+        if (!contains(validSpecialCharactersFirstField, c))
+        {
+            std::cerr << "Invalid piece character: '" << c << "'." << std::endl;
+            return NOK;
+        }
     }
 
     if (v->pieceDrops)
@@ -681,7 +733,7 @@ inline Validation fill_char_board(CharBoard& board, const std::string& fenBoard,
     return OK;
 }
 
-inline Validation check_touching_kings(const CharBoard& board, const std::array<CharSquare, 2>& kingPositions) {
+inline Validation check_touching_kings(const PieceBoard& board, const std::array<CharSquare, 2>& kingPositions) {
     if (non_root_euclidian_distance(kingPositions[WHITE], kingPositions[BLACK]) <= 2)
     {
         std::cerr << "King pieces are next to each other." << std::endl;
@@ -752,7 +804,7 @@ inline std::string castling_rights_to_string(CastlingRights castlingRights) {
     }
 }
 
-inline Validation check_castling_rank(const std::array<std::string, 2>& castlingInfoSplitted, const CharBoard& board,
+inline Validation check_castling_rank(const std::array<std::string, 2>& castlingInfoSplitted, const PieceBoard& board,
                             const std::array<CharSquare, 2>& kingPositions, const Variant* v) {
 
     for (Color c : {WHITE, BLACK})
@@ -769,11 +821,10 @@ inline Validation check_castling_rank(const std::array<std::string, 2>& castling
                 }
                 bool kingside = tolower(castlingFlag) == 'k';
                 bool castlingRook = false;
-                size_t pcIdx;
                 for (int f = kingside ? board.get_nb_files() - 1 : 0; f != kingPositions[c].fileIdx; kingside ? f-- : f++)
-                    if (   (pcIdx = v->pieceToChar.find(board.get_piece(castlingRank, f))) != std::string::npos
-                        && (v->castlingRookPieces[c] & type_of(Piece(pcIdx)))
-                        && color_of(Piece(pcIdx)) == c)
+                    if (   board.get_piece(castlingRank, f) != NO_PIECE
+                        && (v->castlingRookPieces[c] & type_of(board.get_piece(castlingRank, f)))
+                        && color_of(board.get_piece(castlingRank, f)) == c)
                     {
                         castlingRook = true;
                         break;
@@ -784,7 +835,7 @@ inline Validation check_castling_rank(const std::array<std::string, 2>& castling
                     return NOK;
                 }
             }
-            else if (board.get_piece(castlingRank, tolower(castlingFlag) - 'a') == ' ')
+            else if (board.get_piece(castlingRank, tolower(castlingFlag) - 'a') == NO_PIECE)
             {
                 std::cerr << "No gating piece for flag " << castlingFlag << std::endl;
                 return NOK;
@@ -794,7 +845,7 @@ inline Validation check_castling_rank(const std::array<std::string, 2>& castling
     return OK;
 }
 
-inline Validation check_standard_castling(std::array<std::string, 2>& castlingInfoSplitted, const CharBoard& board,
+inline Validation check_standard_castling(std::array<std::string, 2>& castlingInfoSplitted, const PieceBoard& board,
                              const std::array<CharSquare, 2>& kingPositions, const std::array<CharSquare, 2>& kingPositionsStart,
                              const std::array<std::vector<CharSquare>, 2>& rookPositionsStart, const Variant* v) {
 
@@ -812,12 +863,11 @@ inline Validation check_standard_castling(std::array<std::string, 2>& castlingIn
         {
             CharSquare rookStartingSquare = castling == QUEEN_SIDE ? rookPositionsStart[c][0] : rookPositionsStart[c][1];
             char targetChar = castling == QUEEN_SIDE ? 'q' : 'k';
-            size_t pcIdx;
             if (castlingInfoSplitted[c].find(targetChar) != std::string::npos)
             {
-                if (   (pcIdx = v->pieceToChar.find(board.get_piece(rookStartingSquare.rowIdx, rookStartingSquare.fileIdx))) == std::string::npos
-                    || !(v->castlingRookPieces[c] & type_of(Piece(pcIdx)))
-                    || color_of(Piece(pcIdx)) != c)
+                if (   board.get_piece(rookStartingSquare.rowIdx, rookStartingSquare.fileIdx) == NO_PIECE
+                    || !(v->castlingRookPieces[c] & type_of(board.get_piece(rookStartingSquare.rowIdx, rookStartingSquare.fileIdx)))
+                    || color_of(board.get_piece(rookStartingSquare.rowIdx, rookStartingSquare.fileIdx)) != c)
                 {
                     std::cerr << "The " << color_to_string(c) << " ROOK on the "<<  castling_rights_to_string(castling) << " has moved. "
                               << castling_rights_to_string(castling) << " castling is no longer valid for " << color_to_string(c) << "." << std::endl;
@@ -832,51 +882,97 @@ inline Validation check_standard_castling(std::array<std::string, 2>& castlingIn
 
 inline Validation check_pocket_info(const std::string& fenBoard, int nbRanks, const Variant* v, std::string& pocket) {
 
-    char stopChar;
-    int offset = 0;
+    pocket.clear();
+    size_t pocketStart = std::string::npos;
+    size_t pocketEnd = std::string::npos;
+
     if (std::count(fenBoard.begin(), fenBoard.end(), '/') == nbRanks)
     {
-        // look for last '/'
-        stopChar = '/';
+        pocketStart = fenBoard.find_last_of('/');
+        if (pocketStart != std::string::npos)
+        {
+            pocketStart += 1;
+            pocketEnd = fenBoard.size();
+        }
     }
     else if (std::count(fenBoard.begin(), fenBoard.end(), '[') == 1)
     {
-        // pocket is defined as [ and ]
-        stopChar = '[';
-        offset = 1;
-        if (*(fenBoard.end()-1) != ']')
+        pocketStart = fenBoard.find('[');
+        pocketEnd = fenBoard.find(']', pocketStart == std::string::npos ? 0 : pocketStart + 1);
+        if (pocketStart == std::string::npos || pocketEnd == std::string::npos)
         {
             std::cerr << "Pocket specification does not end with ']'." << std::endl;
             return NOK;
         }
+        pocketStart += 1;
     }
     else
-        // allow to skip pocket
         return OK;
 
-    // look for last '/'
-    for (auto it = fenBoard.rbegin()+offset; it != fenBoard.rend(); ++it)
+    if (pocketStart == std::string::npos || pocketStart >= fenBoard.size())
+        return OK;
+
+    pocket = fenBoard.substr(pocketStart, pocketEnd == std::string::npos ? std::string::npos : pocketEnd - pocketStart);
+
+    for (size_t i = 0; i < pocket.size(); ++i)
     {
-        const char c = *it;
-        if (c == stopChar)
-            return OK;
-        if (c != '-')
+        char c = pocket[i];
+        if (c == '-' || std::isspace(static_cast<unsigned char>(c)))
+            continue;
+        if (Variant::is_piece_id_start(c))
         {
-            if (!in_any({v->pieceToChar, v->pieceToCharSynonyms}, c))
+            std::string token(1, c);
+            if (i + 1 < pocket.size() && Variant::is_piece_id_suffix(pocket[i + 1]))
             {
-                std::cerr << "Invalid pocket piece: '" << c << "'." << std::endl;
+                token.push_back(pocket[i + 1]);
+                ++i;
+            }
+            if (v->piece_from_symbol(token) == NO_PIECE)
+            {
+                std::cerr << "Invalid pocket piece: '" << token << "'." << std::endl;
                 return NOK;
             }
-            else
-                pocket += c;
+            continue;
+        }
+        std::cerr << "Invalid pocket piece: '" << c << "'." << std::endl;
+        return NOK;
+    }
+    return OK;
+}
+
+inline int count_piece_symbol_in_fen(const std::string& fenBoard, const std::string& symbol) {
+    if (symbol.empty())
+        return 0;
+
+    int count = 0;
+    for (size_t i = 0; i < fenBoard.size(); ++i)
+    {
+        char c = fenBoard[i];
+        if (std::isspace(static_cast<unsigned char>(c)))
+            break;
+        if (c == '+')
+        {
+            if (++i >= fenBoard.size())
+                break;
+            c = fenBoard[i];
+        }
+        if (Variant::is_piece_id_start(c))
+        {
+            std::string token(1, c);
+            if (i + 1 < fenBoard.size() && Variant::is_piece_id_suffix(fenBoard[i + 1]))
+            {
+                token.push_back(fenBoard[i + 1]);
+                ++i;
+            }
+            if (token == symbol)
+                ++count;
         }
     }
-    std::cerr << "Pocket piece closing character '" << stopChar << "' was not found." << std::endl;
-    return NOK;
+    return count;
 }
 
 inline int piece_count(const std::string& fenBoard, Color c, PieceType pt, const Variant* v) {
-    return std::count(fenBoard.begin(), fenBoard.end(), v->pieceToChar[make_piece(c, pt)]);
+    return count_piece_symbol_in_fen(fenBoard, v->piece_symbol(make_piece(c, pt)));
 }
 
 inline Validation check_number_of_kings(const std::string& fenBoard, const std::string& startFenBoard, const Variant* v) {
@@ -912,9 +1008,9 @@ inline Validation check_number_of_kings(const std::string& fenBoard, const std::
 inline Validation check_en_passant_square(const std::string& enPassantInfo) {
     if (enPassantInfo.size() != 1 || enPassantInfo[0] != '-')
     {
-        if (enPassantInfo.size() != 2)
+        if (enPassantInfo.size() < 2)
         {
-            std::cerr << "Invalid en-passant square '" << enPassantInfo << "'. Expects 2 characters. Actual: " << enPassantInfo.size() << " character(s)." << std::endl;
+            std::cerr << "Invalid en-passant square '" << enPassantInfo << "'. Expects at least 2 characters. Actual: " << enPassantInfo.size() << " character(s)." << std::endl;
             return NOK;
         }
         if (!isalpha(enPassantInfo[0]))
@@ -922,11 +1018,12 @@ inline Validation check_en_passant_square(const std::string& enPassantInfo) {
             std::cerr << "Invalid en-passant square '" << enPassantInfo << "'. Expects 1st character to be a letter." << std::endl;
             return NOK;
         }
-        if (!isdigit(enPassantInfo[1]))
-        {
-            std::cerr << "Invalid en-passant square '" << enPassantInfo << "'. Expects 2nd character to be a digit." << std::endl;
-            return NOK;
-        }
+        for (size_t i = 1; i < enPassantInfo.size(); ++i)
+            if (!isdigit(enPassantInfo[i]))
+            {
+                std::cerr << "Invalid en-passant square '" << enPassantInfo << "'. Expects rank digits after file." << std::endl;
+                return NOK;
+            }
     }
     return OK;
 }
@@ -1025,7 +1122,7 @@ inline FenValidation validate_fen(const std::string& fen, const Variant* v, bool
     const int nbRanks = v->maxRank + 1;
     // check for number of files
     const int nbFiles = v->maxFile + 1;
-    CharBoard board(nbRanks, nbFiles);  // create a 2D character board for later geometry checks
+    PieceBoard board(nbRanks, nbFiles);  // create a 2D character board for later geometry checks
 
     if (fill_char_board(board, fenParts[0], validSpecialCharactersFirstField, v) == NOK)
         return FEN_INVALID_BOARD_GEOMETRY;
@@ -1053,8 +1150,8 @@ inline FenValidation validate_fen(const std::string& fen, const Variant* v, bool
             && piece_count(fenParts[0], BLACK, KING, v) - piece_count(pocket, BLACK, KING, v) == 1)
         {
             std::array<CharSquare, 2> kingPositions;
-            kingPositions[WHITE] = board.get_square_for_piece(v->pieceToChar[make_piece(WHITE, KING)]);
-            kingPositions[BLACK] = board.get_square_for_piece(v->pieceToChar[make_piece(BLACK, KING)]);
+            kingPositions[WHITE] = board.get_square_for_piece(make_piece(WHITE, KING));
+            kingPositions[BLACK] = board.get_square_for_piece(make_piece(BLACK, KING));
             if (check_touching_kings(board, kingPositions) == NOK)
                 return FEN_TOUCHING_KINGS;
         }
@@ -1082,10 +1179,10 @@ inline FenValidation validate_fen(const std::string& fen, const Variant* v, bool
         if (castlingInfoSplitted[WHITE].size() != 0 || castlingInfoSplitted[BLACK].size() != 0)
         {
             std::array<CharSquare, 2> kingPositions;
-            kingPositions[WHITE] = board.get_square_for_piece(toupper(v->pieceToChar[v->castlingKingPiece[WHITE]]));
-            kingPositions[BLACK] = board.get_square_for_piece(tolower(v->pieceToChar[v->castlingKingPiece[BLACK]]));
+            kingPositions[WHITE] = board.get_square_for_piece(make_piece(WHITE, v->castlingKingPiece[WHITE]));
+            kingPositions[BLACK] = board.get_square_for_piece(make_piece(BLACK, v->castlingKingPiece[BLACK]));
 
-            CharBoard startBoard(board.get_nb_ranks(), board.get_nb_files());
+            PieceBoard startBoard(board.get_nb_ranks(), board.get_nb_files());
             fill_char_board(startBoard, v->startFen, validSpecialCharactersFirstField, v);
 
             // Check pieces present on castling rank against castling/gating rights
@@ -1096,11 +1193,11 @@ inline FenValidation validate_fen(const std::string& fen, const Variant* v, bool
             if (!v->chess960 && !v->castlingDroppedPiece && !chess960)
             {
                 std::array<CharSquare, 2> kingPositionsStart;
-                kingPositionsStart[WHITE] = startBoard.get_square_for_piece(v->pieceToChar[make_piece(WHITE, v->castlingKingPiece[WHITE])]);
-                kingPositionsStart[BLACK] = startBoard.get_square_for_piece(v->pieceToChar[make_piece(BLACK, v->castlingKingPiece[BLACK])]);
+                kingPositionsStart[WHITE] = startBoard.get_square_for_piece(make_piece(WHITE, v->castlingKingPiece[WHITE]));
+                kingPositionsStart[BLACK] = startBoard.get_square_for_piece(make_piece(BLACK, v->castlingKingPiece[BLACK]));
                 std::array<std::vector<CharSquare>, 2> rookPositionsStart;
-                rookPositionsStart[WHITE] = startBoard.get_squares_for_pieces(WHITE, v->castlingRookPieces[WHITE], v->pieceToChar);
-                rookPositionsStart[BLACK] = startBoard.get_squares_for_pieces(BLACK, v->castlingRookPieces[BLACK], v->pieceToChar);
+                rookPositionsStart[WHITE] = startBoard.get_squares_for_pieces(WHITE, v->castlingRookPieces[WHITE]);
+                rookPositionsStart[BLACK] = startBoard.get_squares_for_pieces(BLACK, v->castlingRookPieces[BLACK]);
 
                 if (check_standard_castling(castlingInfoSplitted, board, kingPositions, kingPositionsStart, rookPositionsStart, v) == NOK)
                     return FEN_INVALID_CASTLING_INFO;

--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -569,7 +569,12 @@ inline Validation check_for_valid_characters(const std::string& firstFenPart, co
         if (isdigit(c) || contains(validSpecialCharactersFirstField, c))
             continue;
         if (c == '+')
-            continue;
+        {
+            if (v && v->shogiStylePromotions)
+                continue;
+            std::cerr << "Invalid piece character: '+'." << std::endl;
+            return NOK;
+        }
         if (Variant::is_piece_id_start(c))
         {
             std::string token(1, c);

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -61,6 +61,7 @@ Magic* magics[] = {BishopMagics, RookMagicsH, RookMagicsV, CannonMagicsH, Cannon
 
 namespace {
 
+#if !defined(VERY_LARGE_BOARDS)
 // Some magics need to be split in order to reduce memory consumption.
 // Otherwise on a 12x10 board they can be >100 MB.
 #ifdef LARGEBOARDS
@@ -93,6 +94,7 @@ namespace {
   Bitboard GrasshopperTableH[0xA00];  // To store horizontal grasshopper attacks
   Bitboard GrasshopperTableV[0xA00];  // To store vertical grasshopper attacks
   Bitboard GrasshopperTableD[0x1480]; // To store diagonal grasshopper attacks
+#endif
 #endif
 
   // Rider directions
@@ -207,22 +209,71 @@ inline Bitboard safe_destination(Square s, int step) {
     return is_ok(to) && distance(s, to) <= 3 ? square_bb(to) : Bitboard(0);
 }
 
+#ifdef VERY_LARGE_BOARDS
+Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied) {
+  switch (R)
+  {
+  case RIDER_BISHOP:
+      return sliding_attack<RIDER>(BishopDirections, s, occupied);
+  case RIDER_ROOK_H:
+      return sliding_attack<RIDER>(RookDirectionsH, s, occupied);
+  case RIDER_ROOK_V:
+      return sliding_attack<RIDER>(RookDirectionsV, s, occupied);
+  case RIDER_CANNON_H:
+      return sliding_attack<HOPPER>(RookDirectionsH, s, occupied);
+  case RIDER_CANNON_V:
+      return sliding_attack<HOPPER>(RookDirectionsV, s, occupied);
+  case RIDER_LAME_DABBABA:
+      return lame_leaper_attack(LameDabbabaDirections, s, occupied);
+  case RIDER_HORSE:
+      return lame_leaper_attack(HorseDirections, s, occupied);
+  case RIDER_ELEPHANT:
+      return lame_leaper_attack(ElephantDirections, s, occupied);
+  case RIDER_JANGGI_ELEPHANT:
+      return lame_leaper_attack(JanggiElephantDirections, s, occupied);
+  case RIDER_CANNON_DIAG:
+      return sliding_attack<HOPPER>(BishopDirections, s, occupied);
+  case RIDER_NIGHTRIDER:
+      return sliding_attack<RIDER>(HorseDirections, s, occupied);
+  case RIDER_GRASSHOPPER_H:
+      return sliding_attack<HOPPER>(GrasshopperDirectionsH, s, occupied);
+  case RIDER_GRASSHOPPER_V:
+      return sliding_attack<HOPPER>(GrasshopperDirectionsV, s, occupied);
+  case RIDER_GRASSHOPPER_D:
+      return sliding_attack<HOPPER>(GrasshopperDirectionsD, s, occupied);
+  default:
+      return Bitboard(0);
+  }
+}
+#endif
+
 
 /// Bitboards::pretty() returns an ASCII representation of a bitboard suitable
 /// to be printed to standard output. Useful for debugging.
 
 std::string Bitboards::pretty(Bitboard b) {
 
-  std::string s = "+---+---+---+---+---+---+---+---+---+---+---+---+\n";
+  auto divider = []() {
+      std::string line = "+";
+      for (File f = FILE_A; f <= FILE_MAX; ++f)
+          line += "---+";
+      line += "\n";
+      return line;
+  };
+
+  std::string s = divider();
 
   for (Rank r = RANK_MAX; r >= RANK_1; --r)
   {
       for (File f = FILE_A; f <= FILE_MAX; ++f)
           s += b & make_square(f, r) ? "| X " : "|   ";
 
-      s += "| " + std::to_string(1 + r) + "\n+---+---+---+---+---+---+---+---+---+---+---+---+\n";
+      s += "| " + std::to_string(1 + r) + "\n" + divider();
   }
-  s += "  a   b   c   d   e   f   g   h   i   j   k   l\n";
+  s += " ";
+  for (File f = FILE_A; f <= FILE_MAX; ++f)
+      s += " " + std::string(1, char('a' + f)) + " ";
+  s += "\n";
 
   return s;
 }
@@ -330,6 +381,7 @@ void Bitboards::init() {
       for (Square s2 = SQ_A1; s2 <= SQ_MAX; ++s2)
               SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
 
+#if !defined(VERY_LARGE_BOARDS)
 #ifdef PRECOMPUTED_MAGICS
   init_magics<RIDER>(RookTableH, RookMagicsH, RookDirectionsH, RookMagicHInit);
   init_magics<RIDER>(RookTableV, RookMagicsV, RookDirectionsV, RookMagicVInit);
@@ -361,6 +413,7 @@ void Bitboards::init() {
   init_magics<HOPPER>(GrasshopperTableV, GrasshopperMagicsV, GrasshopperDirectionsV);
   init_magics<HOPPER>(GrasshopperTableD, GrasshopperMagicsD, GrasshopperDirectionsD);
 #endif
+#endif
 
   init_pieces();
 
@@ -381,6 +434,7 @@ void Bitboards::init() {
 
 namespace {
 
+#if !defined(VERY_LARGE_BOARDS)
   // init_magics() computes all rook and bishop attacks at startup. Magic
   // bitboards are used to look up attacks of sliding pieces. As a reference see
   // www.chessprogramming.org/Magic_Bitboards. In particular, here we use the so
@@ -496,6 +550,7 @@ namespace {
     delete[] reference;
     delete[] epoch;
   }
+#endif
 }
 
 } // namespace Stockfish

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -40,18 +40,34 @@ std::string pretty(Bitboard b);
 
 } // namespace Stockfish::Bitboards
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+constexpr Bitboard AllSquares = ~Bitboard(0);
+#elif defined(LARGEBOARDS)
 constexpr Bitboard AllSquares = ((~Bitboard(0)) >> 8);
 #else
 constexpr Bitboard AllSquares = ~Bitboard(0);
 #endif
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+constexpr Bitboard DarkSquares = (Bitboard(0x5555) | (Bitboard(0xAAAA) << FILE_NB))
+                               | ((Bitboard(0x5555) | (Bitboard(0xAAAA) << FILE_NB)) << (2 * FILE_NB))
+                               | ((Bitboard(0x5555) | (Bitboard(0xAAAA) << FILE_NB)) << (4 * FILE_NB))
+                               | ((Bitboard(0x5555) | (Bitboard(0xAAAA) << FILE_NB)) << (6 * FILE_NB))
+                               | ((Bitboard(0x5555) | (Bitboard(0xAAAA) << FILE_NB)) << (8 * FILE_NB))
+                               | ((Bitboard(0x5555) | (Bitboard(0xAAAA) << FILE_NB)) << (10 * FILE_NB))
+                               | ((Bitboard(0x5555) | (Bitboard(0xAAAA) << FILE_NB)) << (12 * FILE_NB))
+                               | ((Bitboard(0x5555) | (Bitboard(0xAAAA) << FILE_NB)) << (14 * FILE_NB));
+#elif defined(LARGEBOARDS)
 constexpr Bitboard DarkSquares = (Bitboard(0xAAA555AAA555AAULL) << 64) ^ Bitboard(0xA555AAA555AAA555ULL);
 #else
 constexpr Bitboard DarkSquares = 0xAA55AA55AA55AA55ULL;
 #endif
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+constexpr Bitboard FileABB = Bitboard(0x0001000100010001ULL)
+                           | (Bitboard(0x0001000100010001ULL) << 64)
+                           | (Bitboard(0x0001000100010001ULL) << 128)
+                           | (Bitboard(0x0001000100010001ULL) << 192);
+#elif defined(LARGEBOARDS)
 constexpr Bitboard FileABB = (Bitboard(0x00100100100100ULL) << 64) ^ Bitboard(0x1001001001001001ULL);
 #else
 constexpr Bitboard FileABB = 0x0101010101010101ULL;
@@ -69,9 +85,17 @@ constexpr Bitboard FileJBB = FileABB << 9;
 constexpr Bitboard FileKBB = FileABB << 10;
 constexpr Bitboard FileLBB = FileABB << 11;
 #endif
+#ifdef VERY_LARGE_BOARDS
+constexpr Bitboard FileMBB = FileABB << 12;
+constexpr Bitboard FileNBB = FileABB << 13;
+constexpr Bitboard FileOBB = FileABB << 14;
+constexpr Bitboard FilePBB = FileABB << 15;
+#endif
 
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+constexpr Bitboard Rank1BB = 0xFFFF;
+#elif defined(LARGEBOARDS)
 constexpr Bitboard Rank1BB = 0xFFF;
 #else
 constexpr Bitboard Rank1BB = 0xFF;
@@ -86,6 +110,14 @@ constexpr Bitboard Rank8BB = Rank1BB << (FILE_NB * 7);
 #ifdef LARGEBOARDS
 constexpr Bitboard Rank9BB = Rank1BB << (FILE_NB * 8);
 constexpr Bitboard Rank10BB = Rank1BB << (FILE_NB * 9);
+#endif
+#ifdef VERY_LARGE_BOARDS
+constexpr Bitboard Rank11BB = Rank1BB << (FILE_NB * 10);
+constexpr Bitboard Rank12BB = Rank1BB << (FILE_NB * 11);
+constexpr Bitboard Rank13BB = Rank1BB << (FILE_NB * 12);
+constexpr Bitboard Rank14BB = Rank1BB << (FILE_NB * 13);
+constexpr Bitboard Rank15BB = Rank1BB << (FILE_NB * 14);
+constexpr Bitboard Rank16BB = Rank1BB << (FILE_NB * 15);
 #endif
 
 constexpr Bitboard QueenSide   = FileABB | FileBBB | FileCBB | FileDBB;
@@ -399,7 +431,17 @@ template<> inline int distance<Square>(Square x, Square y) { return SquareDistan
 inline int edge_distance(File f, File maxFile = FILE_H) { return std::min(f, File(maxFile - f)); }
 inline int edge_distance(Rank r, Rank maxRank = RANK_8) { return std::min(r, Rank(maxRank - r)); }
 
+#ifdef VERY_LARGE_BOARDS
+Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied);
 
+template<RiderType R>
+inline Bitboard rider_attacks_bb(Square s, Bitboard occupied) {
+  static_assert(R != NO_RIDER && !(R & (R - 1))); // exactly one bit
+  return rider_attacks_bb(R, s, occupied);
+}
+
+inline Square lsb(Bitboard b);
+#else
 template<RiderType R>
 inline Bitboard rider_attacks_bb(Square s, Bitboard occupied) {
 
@@ -429,6 +471,7 @@ inline Bitboard rider_attacks_bb(RiderType R, Square s, Bitboard occupied) {
   const Magic& m = magics[lsb(R)][s]; // re-use Bitboard lsb for riders
   return m.attacks[m.index(occupied)];
 }
+#endif
 
 
 /// attacks_bb(Square) returns the pseudo attacks of the give piece type
@@ -495,7 +538,13 @@ inline int popcount(Bitboard b) {
 
 #ifndef USE_POPCNT
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  union { Bitboard bb; uint16_t u[16]; } v = { b };
+  return  PopCnt16[v.u[0]] + PopCnt16[v.u[1]] + PopCnt16[v.u[2]] + PopCnt16[v.u[3]]
+        + PopCnt16[v.u[4]] + PopCnt16[v.u[5]] + PopCnt16[v.u[6]] + PopCnt16[v.u[7]]
+        + PopCnt16[v.u[8]] + PopCnt16[v.u[9]] + PopCnt16[v.u[10]] + PopCnt16[v.u[11]]
+        + PopCnt16[v.u[12]] + PopCnt16[v.u[13]] + PopCnt16[v.u[14]] + PopCnt16[v.u[15]];
+#elif defined(LARGEBOARDS)
   union { Bitboard bb; uint16_t u[8]; } v = { b };
   return  PopCnt16[v.u[0]] + PopCnt16[v.u[1]] + PopCnt16[v.u[2]] + PopCnt16[v.u[3]]
         + PopCnt16[v.u[4]] + PopCnt16[v.u[5]] + PopCnt16[v.u[6]] + PopCnt16[v.u[7]];
@@ -506,7 +555,10 @@ inline int popcount(Bitboard b) {
 
 #elif defined(_MSC_VER) || defined(__INTEL_COMPILER)
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  return (int)_mm_popcnt_u64(b.b64[0]) + (int)_mm_popcnt_u64(b.b64[1])
+       + (int)_mm_popcnt_u64(b.b64[2]) + (int)_mm_popcnt_u64(b.b64[3]);
+#elif defined(LARGEBOARDS)
   return (int)_mm_popcnt_u64(uint64_t(b >> 64)) + (int)_mm_popcnt_u64(uint64_t(b));
 #else
   return (int)_mm_popcnt_u64(b);
@@ -514,7 +566,10 @@ inline int popcount(Bitboard b) {
 
 #else // Assumed gcc or compatible compiler
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  return __builtin_popcountll(b.b64[0]) + __builtin_popcountll(b.b64[1])
+       + __builtin_popcountll(b.b64[2]) + __builtin_popcountll(b.b64[3]);
+#elif defined(LARGEBOARDS)
   return __builtin_popcountll(b >> 64) + __builtin_popcountll(b);
 #else
   return __builtin_popcountll(b);
@@ -530,7 +585,15 @@ inline int popcount(Bitboard b) {
 
 inline Square lsb(Bitboard b) {
   assert(b);
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  if (b.b64[3])
+      return Square(__builtin_ctzll(b.b64[3]));
+  if (b.b64[2])
+      return Square(__builtin_ctzll(b.b64[2]) + 64);
+  if (b.b64[1])
+      return Square(__builtin_ctzll(b.b64[1]) + 128);
+  return Square(__builtin_ctzll(b.b64[0]) + 192);
+#elif defined(LARGEBOARDS)
   if (!(b << 64))
       return Square(__builtin_ctzll(b >> 64) + 64);
 #endif
@@ -539,7 +602,15 @@ inline Square lsb(Bitboard b) {
 
 inline Square msb(Bitboard b) {
   assert(b);
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  if (b.b64[0])
+      return Square(192 + 63 - __builtin_clzll(b.b64[0]));
+  if (b.b64[1])
+      return Square(128 + 63 - __builtin_clzll(b.b64[1]));
+  if (b.b64[2])
+      return Square(64 + 63 - __builtin_clzll(b.b64[2]));
+  return Square(63 - __builtin_clzll(b.b64[3]));
+#elif defined(LARGEBOARDS)
   if (b >> 64)
       return Square(int(SQUARE_BIT_MASK) ^ __builtin_clzll(b >> 64));
   return Square(int(SQUARE_BIT_MASK) ^ (__builtin_clzll(b) + 64));
@@ -555,7 +626,25 @@ inline Square msb(Bitboard b) {
 inline Square lsb(Bitboard b) {
   assert(b);
   unsigned long idx;
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  if (b.b64[3])
+  {
+      _BitScanForward64(&idx, b.b64[3]);
+      return Square(idx);
+  }
+  if (b.b64[2])
+  {
+      _BitScanForward64(&idx, b.b64[2]);
+      return Square(idx + 64);
+  }
+  if (b.b64[1])
+  {
+      _BitScanForward64(&idx, b.b64[1]);
+      return Square(idx + 128);
+  }
+  _BitScanForward64(&idx, b.b64[0]);
+  return Square(idx + 192);
+#elif defined(LARGEBOARDS)
   if (uint64_t(b))
   {
       _BitScanForward64(&idx, uint64_t(b));
@@ -575,7 +664,25 @@ inline Square lsb(Bitboard b) {
 inline Square msb(Bitboard b) {
   assert(b);
   unsigned long idx;
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  if (b.b64[0])
+  {
+      _BitScanReverse64(&idx, b.b64[0]);
+      return Square(idx + 192);
+  }
+  if (b.b64[1])
+  {
+      _BitScanReverse64(&idx, b.b64[1]);
+      return Square(idx + 128);
+  }
+  if (b.b64[2])
+  {
+      _BitScanReverse64(&idx, b.b64[2]);
+      return Square(idx + 64);
+  }
+  _BitScanReverse64(&idx, b.b64[3]);
+  return Square(idx);
+#elif defined(LARGEBOARDS)
   if (b >> 64)
   {
       _BitScanReverse64(&idx, uint64_t(b >> 64));
@@ -598,7 +705,33 @@ inline Square lsb(Bitboard b) {
   assert(b);
   unsigned long idx;
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  if (b.b64[3] & 0xffffffff) {
+      _BitScanForward(&idx, uint32_t(b.b64[3]));
+      return Square(idx);
+  } else if (b.b64[3] >> 32) {
+      _BitScanForward(&idx, uint32_t(b.b64[3] >> 32));
+      return Square(idx + 32);
+  } else if (b.b64[2] & 0xffffffff) {
+      _BitScanForward(&idx, uint32_t(b.b64[2]));
+      return Square(idx + 64);
+  } else if (b.b64[2] >> 32) {
+      _BitScanForward(&idx, uint32_t(b.b64[2] >> 32));
+      return Square(idx + 96);
+  } else if (b.b64[1] & 0xffffffff) {
+      _BitScanForward(&idx, uint32_t(b.b64[1]));
+      return Square(idx + 128);
+  } else if (b.b64[1] >> 32) {
+      _BitScanForward(&idx, uint32_t(b.b64[1] >> 32));
+      return Square(idx + 160);
+  } else if (b.b64[0] & 0xffffffff) {
+      _BitScanForward(&idx, uint32_t(b.b64[0]));
+      return Square(idx + 192);
+  } else {
+      _BitScanForward(&idx, uint32_t(b.b64[0] >> 32));
+      return Square(idx + 224);
+  }
+#elif defined(LARGEBOARDS)
   if (b << 96) {
       _BitScanForward(&idx, uint32_t(b));
       return Square(idx);
@@ -627,22 +760,47 @@ inline Square msb(Bitboard b) {
   assert(b);
   unsigned long idx;
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  if (b.b64[0] >> 32) {
+      _BitScanReverse(&idx, uint32_t(b.b64[0] >> 32));
+      return Square(idx + 224);
+  } else if (b.b64[0] & 0xffffffff) {
+      _BitScanReverse(&idx, uint32_t(b.b64[0]));
+      return Square(idx + 192);
+  } else if (b.b64[1] >> 32) {
+      _BitScanReverse(&idx, uint32_t(b.b64[1] >> 32));
+      return Square(idx + 160);
+  } else if (b.b64[1] & 0xffffffff) {
+      _BitScanReverse(&idx, uint32_t(b.b64[1]));
+      return Square(idx + 128);
+  } else if (b.b64[2] >> 32) {
+      _BitScanReverse(&idx, uint32_t(b.b64[2] >> 32));
+      return Square(idx + 96);
+  } else if (b.b64[2] & 0xffffffff) {
+      _BitScanReverse(&idx, uint32_t(b.b64[2]));
+      return Square(idx + 64);
+  } else if (b.b64[3] >> 32) {
+      _BitScanReverse(&idx, uint32_t(b.b64[3] >> 32));
+      return Square(idx + 32);
+  } else {
+      _BitScanReverse(&idx, uint32_t(b.b64[3]));
+      return Square(idx);
+  }
+#else
   if (b >> 96) {
       _BitScanReverse(&idx, uint32_t(b >> 96));
       return Square(idx + 96);
   } else if (b >> 64) {
       _BitScanReverse(&idx, uint32_t(b >> 64));
       return Square(idx + 64);
-  } else
-#endif
-  if (b >> 32) {
+  } else if (b >> 32) {
       _BitScanReverse(&idx, uint32_t(b >> 32));
       return Square(idx + 32);
   } else {
       _BitScanReverse(&idx, uint32_t(b));
       return Square(idx);
   }
+#endif
 }
 
 #endif

--- a/src/ffishjs.cpp
+++ b/src/ffishjs.cpp
@@ -387,7 +387,7 @@ public:
     for (PieceType pt = KING; pt >= PAWN; --pt) {
       for (int i = 0; i < pos.count_in_hand(c, pt); ++i) {
         // only create BLACK pieces in order to convert to lower case
-        pocket += std::string(1, pos.piece_to_char()[make_piece(BLACK, pt)]);
+        pocket += pos.piece_symbol(make_piece(BLACK, pt));
       }
     }
     return pocket;
@@ -405,7 +405,7 @@ public:
           stringBoard += '.';
           break;
         default:
-          stringBoard += pos.piece_to_char()[p];
+          stringBoard += pos.piece_symbol(p);
         }
       }
       if (r != RANK_1)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -156,7 +156,9 @@ string engine_info(bool to_uci, bool to_xboard) {
       ss << setw(2) << day << setw(2) << (1 + months.find(month) / 4) << year.substr(2);
   }
 
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  ss << " VLB";
+#elif defined(LARGEBOARDS)
   ss << " LB";
 #endif
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -110,12 +110,12 @@ void MovePicker::score() {
   for (auto& m : *this)
       if constexpr (Type == CAPTURES)
           m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
-                   + (*gateHistory)[pos.side_to_move()][gating_square(m)]
+                   + (*gateHistory)[pos.side_to_move()][pos.gate_square(m)]
                    + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
       else if constexpr (Type == QUIETS)
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
-                   +     (*gateHistory)[pos.side_to_move()][gating_square(m)]
+                   +     (*gateHistory)[pos.side_to_move()][pos.gate_square(m)]
                    + 2 * (*continuationHistory[0])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[1])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[3])[history_slot(pos.moved_piece(m))][to_sq(m)]

--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -314,7 +314,7 @@ namespace Stockfish::Eval::NNUE {
          board[y+i][x] = board[y+i][x+8] = '|';
       board[y][x] = board[y][x+8] = board[y+3][x+8] = board[y+3][x] = '+';
       if (pc != NO_PIECE)
-        board[y+1][x+4] = pos.piece_to_char()[pc];
+        board[y+1][x+4] = pos.piece_symbol(pc).empty() ? ' ' : pos.piece_symbol(pc)[0];
       if (value != VALUE_NONE)
         format_cp_compact(value, &board[y+2][x+2]);
     };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -28,6 +28,42 @@ namespace Stockfish {
 
 namespace {
 
+    std::string trim(const std::string& s) {
+        size_t first = 0;
+        while (first < s.size() && std::isspace(static_cast<unsigned char>(s[first])))
+            ++first;
+        size_t last = s.size();
+        while (last > first && std::isspace(static_cast<unsigned char>(s[last - 1])))
+            --last;
+        return s.substr(first, last - first);
+    }
+
+    bool read_piece_token(const std::string& value, size_t& pos, std::string& token) {
+        token.clear();
+        while (pos < value.size() && std::isspace(static_cast<unsigned char>(value[pos])))
+            ++pos;
+        if (pos >= value.size())
+            return false;
+        char c = value[pos];
+        token.push_back(c);
+        ++pos;
+        if (Variant::is_piece_id_start(c) && pos < value.size() && Variant::is_piece_id_suffix(value[pos]))
+        {
+            token.push_back(value[pos]);
+            ++pos;
+        }
+        return true;
+    }
+
+    bool split_piece_entry(const std::string& entry, std::string& left, std::string& right) {
+        size_t sep = entry.find(':');
+        if (sep == std::string::npos)
+            return false;
+        left = trim(entry.substr(0, sep));
+        right = trim(entry.substr(sep + 1));
+        return !left.empty() && !right.empty();
+    }
+
     template <typename T> bool set(const std::string& value, T& target)
     {
         std::stringstream ss(value);
@@ -220,19 +256,34 @@ template <bool Current, class T> bool VariantParser<DoCheck>::parse_attribute(co
 }
 
 template <bool DoCheck>
-template <bool Current, class T> bool VariantParser<DoCheck>::parse_attribute(const std::string& key, T& target, std::string pieceToChar) {
+template <bool Current, class T> bool VariantParser<DoCheck>::parse_attribute(const std::string& key, T& target, const Variant* v) {
     const auto& it = config.find(key);
     if (it != config.end())
     {
         target = T();
-        char token;
-        size_t idx = std::string::npos;
-        std::stringstream ss(it->second);
-        while (ss >> token && (idx = token == '*' ? size_t(ALL_PIECES) : pieceToChar.find(toupper(token))) != std::string::npos)
-            set(PieceType(idx), target);
-        if (DoCheck && idx == std::string::npos && token != '-')
+        bool ok = true;
+        std::string token;
+        size_t pos = 0;
+        while (read_piece_token(it->second, pos, token))
+        {
+            if (token == "-")
+                return true;
+            if (token == "*")
+            {
+                set(ALL_PIECES, target);
+                continue;
+            }
+            PieceType pt = v->piece_type_from_symbol(token);
+            if (pt == NO_PIECE_TYPE)
+            {
+                ok = false;
+                break;
+            }
+            set(pt, target);
+        }
+        if (DoCheck && !ok)
             std::cerr << key << " - Invalid piece type: " << token << std::endl;
-        return idx != std::string::npos || token == '-';
+        return ok;
     }
     return false;
 }
@@ -261,22 +312,39 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
         const auto& keyValue = config.find(name);
         if (keyValue != config.end() && !keyValue->second.empty())
         {
-            if (isalpha(keyValue->second.at(0)))
-                v->add_piece(pt, keyValue->second.at(0));
+            std::string value = trim(keyValue->second);
+            std::string token = value;
+            std::string betza;
+            size_t sep = value.find(':');
+            if (sep != std::string::npos)
+            {
+                token = trim(value.substr(0, sep));
+                betza = trim(value.substr(sep + 1));
+            }
+
+            if (!token.empty() && token[0] != '-')
+            {
+                if (!Variant::normalize_piece_symbol(token, WHITE).empty())
+                    v->add_piece(pt, token, betza);
+                else
+                {
+                    if (DoCheck)
+                        std::cerr << name << " - Invalid letter: " << token << std::endl;
+                    v->remove_piece(pt);
+                }
+            }
             else
             {
-                if (DoCheck && keyValue->second.at(0) != '-')
-                    std::cerr << name << " - Invalid letter: " << keyValue->second.at(0) << std::endl;
+                if (DoCheck && !token.empty() && token[0] != '-')
+                    std::cerr << name << " - Invalid letter: " << token << std::endl;
                 v->remove_piece(pt);
             }
-            // betza
+
             if (is_custom(pt))
             {
-                if (keyValue->second.size() > 1)
+                if (!betza.empty())
                 {
-                    v->customPiece[pt - CUSTOM_PIECES] = keyValue->second.substr(2);
-                    // Is there an en passant flag in the Betza notation?
-                    if (v->customPiece[pt - CUSTOM_PIECES].find('e') != std::string::npos)
+                    if (betza.find('e') != std::string::npos)
                     {
                         v->enPassantTypes[WHITE] |= piece_set(pt);
                         v->enPassantTypes[BLACK] |= piece_set(pt);
@@ -287,10 +355,9 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
             }
             else if (pt == KING)
             {
-                if (keyValue->second.size() > 1)
+                if (!betza.empty())
                 {
-                    // custom royal piece
-                    v->customPiece[CUSTOM_PIECES_ROYAL - CUSTOM_PIECES] = keyValue->second.substr(2);
+                    v->customPiece[CUSTOM_PIECES_ROYAL - CUSTOM_PIECES] = betza;
                     v->kingType = CUSTOM_PIECES_ROYAL;
                 }
                 else
@@ -306,6 +373,8 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
             parse_attribute("mobilityRegion" + color + capitalizedPiece, v->mobilityRegion[c][pt]);
         }
     }
+    v->rebuild_piece_symbol_maps();
+
     // piece values
     for (Phase phase : {MG, EG})
     {
@@ -313,15 +382,31 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
         const auto& pv = config.find(optionName);
         if (pv != config.end())
         {
-            char token;
-            size_t idx = 0;
+            bool ok = true;
+            std::string entry;
             std::stringstream ss(pv->second);
-            while (!ss.eof() && ss >> token && (idx = v->pieceToChar.find(toupper(token))) != std::string::npos
-                             && ss >> token && ss >> v->pieceValue[phase][idx]) {}
-            if (DoCheck && idx == std::string::npos)
-                std::cerr << optionName << " - Invalid piece type: " << token << std::endl;
-            else if (DoCheck && !ss.eof())
-                std::cerr << optionName << " - Invalid piece value for type: " << v->pieceToChar[idx] << std::endl;
+            while (ss >> entry)
+            {
+                std::string token;
+                std::string valueToken;
+                if (!split_piece_entry(entry, token, valueToken))
+                {
+                    ok = false;
+                    break;
+                }
+                PieceType pt = v->piece_type_from_symbol(token);
+                int value = 0;
+                std::stringstream vs(valueToken);
+                vs >> value;
+                if (pt == NO_PIECE_TYPE || vs.fail())
+                {
+                    ok = false;
+                    break;
+                }
+                v->pieceValue[phase][pt] = value;
+            }
+            if (DoCheck && !ok)
+                std::cerr << optionName << " - Invalid piece values: " << pv->second << std::endl;
         }
     }
 
@@ -343,8 +428,8 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     }
     parse_attribute<false>("whiteFlag", v->flagRegion[WHITE]);
     parse_attribute<false>("blackFlag", v->flagRegion[BLACK]);
-    parse_attribute<false>("castlingRookPiece", v->castlingRookPieces[WHITE], v->pieceToChar);
-    parse_attribute<false>("castlingRookPiece", v->castlingRookPieces[BLACK], v->pieceToChar);
+    parse_attribute<false>("castlingRookPiece", v->castlingRookPieces[WHITE], v);
+    parse_attribute<false>("castlingRookPiece", v->castlingRookPieces[BLACK], v);
     parse_attribute<false>("whiteDropRegion", v->dropRegion[WHITE]);
     parse_attribute<false>("blackDropRegion", v->dropRegion[BLACK]);
 
@@ -353,14 +438,14 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     if (dropOnTop) v->enclosingDrop=TOP;
 
     // Parse aliases
-    parse_attribute("pawnTypes", v->mainPromotionPawnType[WHITE], v->pieceToChar);
-    parse_attribute("pawnTypes", v->mainPromotionPawnType[BLACK], v->pieceToChar);
-    parse_attribute("pawnTypes", v->promotionPawnTypes[WHITE], v->pieceToChar);
-    parse_attribute("pawnTypes", v->promotionPawnTypes[BLACK], v->pieceToChar);
-    parse_attribute("pawnTypes", v->enPassantTypes[WHITE], v->pieceToChar);
-    parse_attribute("pawnTypes", v->enPassantTypes[BLACK], v->pieceToChar);
-    parse_attribute("pawnTypes", v->nMoveRuleTypes[WHITE], v->pieceToChar);
-    parse_attribute("pawnTypes", v->nMoveRuleTypes[BLACK], v->pieceToChar);
+    parse_attribute("pawnTypes", v->mainPromotionPawnType[WHITE], v);
+    parse_attribute("pawnTypes", v->mainPromotionPawnType[BLACK], v);
+    parse_attribute("pawnTypes", v->promotionPawnTypes[WHITE], v);
+    parse_attribute("pawnTypes", v->promotionPawnTypes[BLACK], v);
+    parse_attribute("pawnTypes", v->enPassantTypes[WHITE], v);
+    parse_attribute("pawnTypes", v->enPassantTypes[BLACK], v);
+    parse_attribute("pawnTypes", v->nMoveRuleTypes[WHITE], v);
+    parse_attribute("pawnTypes", v->nMoveRuleTypes[BLACK], v);
 
     // Parse the official config options
     parse_attribute("variantTemplate", v->variantTemplate);
@@ -372,54 +457,87 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("promotionRegionWhite", v->promotionRegion[WHITE]);
     parse_attribute("promotionRegionBlack", v->promotionRegion[BLACK]);
     // Take the first promotionPawnTypes as the main promotionPawnType
-    parse_attribute("promotionPawnTypes", v->mainPromotionPawnType[WHITE], v->pieceToChar);
-    parse_attribute("promotionPawnTypes", v->mainPromotionPawnType[BLACK], v->pieceToChar);
-    parse_attribute("promotionPawnTypes", v->promotionPawnTypes[WHITE], v->pieceToChar);
-    parse_attribute("promotionPawnTypes", v->promotionPawnTypes[BLACK], v->pieceToChar);
-    parse_attribute("promotionPawnTypesWhite", v->mainPromotionPawnType[WHITE], v->pieceToChar);
-    parse_attribute("promotionPawnTypesBlack", v->mainPromotionPawnType[BLACK], v->pieceToChar);
-    parse_attribute("promotionPawnTypesWhite", v->promotionPawnTypes[WHITE], v->pieceToChar);
-    parse_attribute("promotionPawnTypesBlack", v->promotionPawnTypes[BLACK], v->pieceToChar);
-    parse_attribute("promotionPieceTypes", v->promotionPieceTypes[WHITE], v->pieceToChar);
-    parse_attribute("promotionPieceTypes", v->promotionPieceTypes[BLACK], v->pieceToChar);
-    parse_attribute("promotionPieceTypesWhite", v->promotionPieceTypes[WHITE], v->pieceToChar);
-    parse_attribute("promotionPieceTypesBlack", v->promotionPieceTypes[BLACK], v->pieceToChar);
+    parse_attribute("promotionPawnTypes", v->mainPromotionPawnType[WHITE], v);
+    parse_attribute("promotionPawnTypes", v->mainPromotionPawnType[BLACK], v);
+    parse_attribute("promotionPawnTypes", v->promotionPawnTypes[WHITE], v);
+    parse_attribute("promotionPawnTypes", v->promotionPawnTypes[BLACK], v);
+    parse_attribute("promotionPawnTypesWhite", v->mainPromotionPawnType[WHITE], v);
+    parse_attribute("promotionPawnTypesBlack", v->mainPromotionPawnType[BLACK], v);
+    parse_attribute("promotionPawnTypesWhite", v->promotionPawnTypes[WHITE], v);
+    parse_attribute("promotionPawnTypesBlack", v->promotionPawnTypes[BLACK], v);
+    parse_attribute("promotionPieceTypes", v->promotionPieceTypes[WHITE], v);
+    parse_attribute("promotionPieceTypes", v->promotionPieceTypes[BLACK], v);
+    parse_attribute("promotionPieceTypesWhite", v->promotionPieceTypes[WHITE], v);
+    parse_attribute("promotionPieceTypesBlack", v->promotionPieceTypes[BLACK], v);
     parse_attribute("sittuyinPromotion", v->sittuyinPromotion);
     // promotion limit
     const auto& it_prom_limit = config.find("promotionLimit");
     if (it_prom_limit != config.end())
     {
-        char token;
-        size_t idx = 0;
+        bool ok = true;
+        std::string entry;
         std::stringstream ss(it_prom_limit->second);
-        while (!ss.eof() && ss >> token && (idx = v->pieceToChar.find(toupper(token))) != std::string::npos
-                         && ss >> token && ss >> v->promotionLimit[idx]) {}
-        if (DoCheck && idx == std::string::npos)
-            std::cerr << "promotionLimit - Invalid piece type: " << token << std::endl;
-        else if (DoCheck && !ss.eof())
-            std::cerr << "promotionLimit - Invalid piece count for type: " << v->pieceToChar[idx] << std::endl;
+        while (ss >> entry)
+        {
+            std::string token;
+            std::string countToken;
+            if (!split_piece_entry(entry, token, countToken))
+            {
+                ok = false;
+                break;
+            }
+            PieceType pt = v->piece_type_from_symbol(token);
+            int count = 0;
+            std::stringstream cs(countToken);
+            cs >> count;
+            if (pt == NO_PIECE_TYPE || cs.fail())
+            {
+                ok = false;
+                break;
+            }
+            v->promotionLimit[pt] = count;
+        }
+        if (DoCheck && !ok)
+            std::cerr << "promotionLimit - Invalid piece count: " << it_prom_limit->second << std::endl;
     }
     // promoted piece types
     const auto& it_prom_pt = config.find("promotedPieceType");
     if (it_prom_pt != config.end())
     {
-        char token;
-        size_t idx = 0, idx2 = 0;
+        bool ok = true;
+        std::string entry;
         std::stringstream ss(it_prom_pt->second);
-        while (   ss >> token && (idx = v->pieceToChar.find(toupper(token))) != std::string::npos && ss >> token
-               && ss >> token && (idx2 = (token == '-' ? 0 : v->pieceToChar.find(toupper(token)))) != std::string::npos)
-            v->promotedPieceType[idx] = PieceType(idx2);
-        if (DoCheck && (idx == std::string::npos || idx2 == std::string::npos))
-            std::cerr << "promotedPieceType - Invalid piece type: " << token << std::endl;
+        while (ss >> entry)
+        {
+            std::string fromToken;
+            std::string toToken;
+            if (!split_piece_entry(entry, fromToken, toToken))
+            {
+                ok = false;
+                break;
+            }
+            PieceType from = v->piece_type_from_symbol(fromToken);
+            PieceType to = NO_PIECE_TYPE;
+            if (toToken != "-")
+                to = v->piece_type_from_symbol(toToken);
+            if (from == NO_PIECE_TYPE || (toToken != "-" && to == NO_PIECE_TYPE))
+            {
+                ok = false;
+                break;
+            }
+            v->promotedPieceType[from] = to;
+        }
+        if (DoCheck && !ok)
+            std::cerr << "promotedPieceType - Invalid piece type: " << it_prom_pt->second << std::endl;
     }
     parse_attribute("piecePromotionOnCapture", v->piecePromotionOnCapture);
     parse_attribute("mandatoryPawnPromotion", v->mandatoryPawnPromotion);
     parse_attribute("mandatoryPiecePromotion", v->mandatoryPiecePromotion);
     parse_attribute("pieceDemotion", v->pieceDemotion);
     parse_attribute("blastOnCapture", v->blastOnCapture);
-    parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v->pieceToChar);
-    parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v->pieceToChar);
-    parse_attribute("petrifyOnCaptureTypes", v->petrifyOnCaptureTypes, v->pieceToChar);
+    parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v);
+    parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v);
+    parse_attribute("petrifyOnCaptureTypes", v->petrifyOnCaptureTypes, v);
     parse_attribute("petrifyBlastPieces", v->petrifyBlastPieces);
     parse_attribute("doubleStep", v->doubleStep);
     parse_attribute("doubleStepRegionWhite", v->doubleStepRegion[WHITE]);
@@ -430,32 +548,32 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("enPassantRegion", v->enPassantRegion[BLACK]);
     parse_attribute("enPassantRegionWhite", v->enPassantRegion[WHITE]);
     parse_attribute("enPassantRegionBlack", v->enPassantRegion[BLACK]);
-    parse_attribute("enPassantTypes", v->enPassantTypes[WHITE], v->pieceToChar);
-    parse_attribute("enPassantTypes", v->enPassantTypes[BLACK], v->pieceToChar);
-    parse_attribute("enPassantTypesWhite", v->enPassantTypes[WHITE], v->pieceToChar);
-    parse_attribute("enPassantTypesBlack", v->enPassantTypes[BLACK], v->pieceToChar);
+    parse_attribute("enPassantTypes", v->enPassantTypes[WHITE], v);
+    parse_attribute("enPassantTypes", v->enPassantTypes[BLACK], v);
+    parse_attribute("enPassantTypesWhite", v->enPassantTypes[WHITE], v);
+    parse_attribute("enPassantTypesBlack", v->enPassantTypes[BLACK], v);
     parse_attribute("castling", v->castling);
     parse_attribute("castlingDroppedPiece", v->castlingDroppedPiece);
     parse_attribute("castlingKingsideFile", v->castlingKingsideFile);
     parse_attribute("castlingQueensideFile", v->castlingQueensideFile);
     parse_attribute("castlingRank", v->castlingRank);
     parse_attribute("castlingKingFile", v->castlingKingFile);
-    parse_attribute("castlingKingPiece", v->castlingKingPiece[WHITE], v->pieceToChar);
-    parse_attribute("castlingKingPiece", v->castlingKingPiece[BLACK], v->pieceToChar);
-    parse_attribute("castlingKingPieceWhite", v->castlingKingPiece[WHITE], v->pieceToChar);
-    parse_attribute("castlingKingPieceBlack", v->castlingKingPiece[BLACK], v->pieceToChar);
+    parse_attribute("castlingKingPiece", v->castlingKingPiece[WHITE], v);
+    parse_attribute("castlingKingPiece", v->castlingKingPiece[BLACK], v);
+    parse_attribute("castlingKingPieceWhite", v->castlingKingPiece[WHITE], v);
+    parse_attribute("castlingKingPieceBlack", v->castlingKingPiece[BLACK], v);
     parse_attribute("castlingRookKingsideFile", v->castlingRookKingsideFile);
     parse_attribute("castlingRookQueensideFile", v->castlingRookQueensideFile);
-    parse_attribute("castlingRookPieces", v->castlingRookPieces[WHITE], v->pieceToChar);
-    parse_attribute("castlingRookPieces", v->castlingRookPieces[BLACK], v->pieceToChar);
-    parse_attribute("castlingRookPiecesWhite", v->castlingRookPieces[WHITE], v->pieceToChar);
-    parse_attribute("castlingRookPiecesBlack", v->castlingRookPieces[BLACK], v->pieceToChar);
+    parse_attribute("castlingRookPieces", v->castlingRookPieces[WHITE], v);
+    parse_attribute("castlingRookPieces", v->castlingRookPieces[BLACK], v);
+    parse_attribute("castlingRookPiecesWhite", v->castlingRookPieces[WHITE], v);
+    parse_attribute("castlingRookPiecesBlack", v->castlingRookPieces[BLACK], v);
     parse_attribute("oppositeCastling", v->oppositeCastling);
     parse_attribute("checking", v->checking);
     parse_attribute("dropChecks", v->dropChecks);
     parse_attribute("mustCapture", v->mustCapture);
     parse_attribute("mustDrop", v->mustDrop);
-    parse_attribute("mustDropType", v->mustDropType, v->pieceToChar);
+    parse_attribute("mustDropType", v->mustDropType, v);
     parse_attribute("pieceDrops", v->pieceDrops);
     parse_attribute("dropLoop", v->dropLoop);
     parse_attribute("capturesToHand", v->capturesToHand);
@@ -468,7 +586,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("sittuyinRookDrop", v->sittuyinRookDrop);
     parse_attribute("dropOppositeColoredBishop", v->dropOppositeColoredBishop);
     parse_attribute("dropPromoted", v->dropPromoted);
-    parse_attribute("dropNoDoubled", v->dropNoDoubled, v->pieceToChar);
+    parse_attribute("dropNoDoubled", v->dropNoDoubled, v);
     parse_attribute("dropNoDoubledCount", v->dropNoDoubledCount);
     parse_attribute("immobilityIllegal", v->immobilityIllegal);
     parse_attribute("gating", v->gating);
@@ -494,10 +612,10 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("soldierPromotionRank", v->soldierPromotionRank);
     parse_attribute("flipEnclosedPieces", v->flipEnclosedPieces);
     // game end
-    parse_attribute("nMoveRuleTypes", v->nMoveRuleTypes[WHITE], v->pieceToChar);
-    parse_attribute("nMoveRuleTypes", v->nMoveRuleTypes[BLACK], v->pieceToChar);
-    parse_attribute("nMoveRuleTypesWhite", v->nMoveRuleTypes[WHITE], v->pieceToChar);
-    parse_attribute("nMoveRuleTypesBlack", v->nMoveRuleTypes[BLACK], v->pieceToChar);
+    parse_attribute("nMoveRuleTypes", v->nMoveRuleTypes[WHITE], v);
+    parse_attribute("nMoveRuleTypes", v->nMoveRuleTypes[BLACK], v);
+    parse_attribute("nMoveRuleTypesWhite", v->nMoveRuleTypes[WHITE], v);
+    parse_attribute("nMoveRuleTypesBlack", v->nMoveRuleTypes[BLACK], v);
     parse_attribute("nMoveRule", v->nMoveRule);
     parse_attribute("nFoldRule", v->nFoldRule);
     parse_attribute("nFoldValue", v->nFoldValue);
@@ -516,13 +634,13 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("extinctionPseudoRoyal", v->extinctionPseudoRoyal);
     parse_attribute("dupleCheck", v->dupleCheck);
     // extinction piece types
-    parse_attribute("extinctionPieceTypes", v->extinctionPieceTypes, v->pieceToChar);
+    parse_attribute("extinctionPieceTypes", v->extinctionPieceTypes, v);
     parse_attribute("extinctionPieceCount", v->extinctionPieceCount);
     parse_attribute("extinctionOpponentPieceCount", v->extinctionOpponentPieceCount);
-    parse_attribute("flagPiece", v->flagPiece[WHITE], v->pieceToChar);
-    parse_attribute("flagPiece", v->flagPiece[BLACK], v->pieceToChar);
-    parse_attribute("flagPieceWhite", v->flagPiece[WHITE], v->pieceToChar);
-    parse_attribute("flagPieceBlack", v->flagPiece[BLACK], v->pieceToChar);
+    parse_attribute("flagPiece", v->flagPiece[WHITE], v);
+    parse_attribute("flagPiece", v->flagPiece[BLACK], v);
+    parse_attribute("flagPieceWhite", v->flagPiece[WHITE], v);
+    parse_attribute("flagPieceBlack", v->flagPiece[BLACK], v);
     parse_attribute("flagRegion", v->flagRegion[WHITE]);
     parse_attribute("flagRegion", v->flagRegion[BLACK]);
     parse_attribute("flagRegionWhite", v->flagRegion[WHITE]);
@@ -533,7 +651,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("flagPieceSafe", v->flagPieceSafe);
     parse_attribute("checkCounting", v->checkCounting);
     parse_attribute("connectN", v->connectN);
-    parse_attribute("connectPieceTypes", v->connectPieceTypes, v->pieceToChar);
+    parse_attribute("connectPieceTypes", v->connectPieceTypes, v);
     parse_attribute("connectHorizontal", v->connectHorizontal);
     parse_attribute("connectVertical", v->connectVertical);
     parse_attribute("connectDiagonal", v->connectDiagonal);
@@ -561,12 +679,16 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     if (DoCheck)
     {
         // pieces
+        std::set<std::string> pieceSymbols;
         for (PieceSet ps = v->pieceTypes; ps;)
         {
             PieceType pt = pop_lsb(ps);
             for (Color c : {WHITE, BLACK})
-                if (std::count(v->pieceToChar.begin(), v->pieceToChar.end(), v->pieceToChar[make_piece(c, pt)]) != 1)
-                    std::cerr << piece_name(pt) << " - Ambiguous piece character: " << v->pieceToChar[make_piece(c, pt)] << std::endl;
+            {
+                std::string sym = v->piece_symbol(make_piece(c, pt));
+                if (!sym.empty() && !pieceSymbols.insert(sym).second)
+                    std::cerr << piece_name(pt) << " - Ambiguous piece symbol: " << sym << std::endl;
+            }
         }
 
         v->conclude(); // In preparation for the consistency checks below
@@ -582,7 +704,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
             std::stringstream ss(v->pieceToCharTable);
             char token;
             while (ss >> token)
-                if (isalpha(token) && v->pieceToChar.find(toupper(token)) == std::string::npos)
+                if (isalpha(token) && v->piece_type_from_symbol(std::string(1, token)) == NO_PIECE_TYPE)
                     std::cerr << "pieceToCharTable - Invalid piece type: " << token << std::endl;
             for (PieceSet ps = v->pieceTypes; ps;)
             {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -297,6 +297,52 @@ Variant* VariantParser<DoCheck>::parse() {
 
 template <bool DoCheck>
 Variant* VariantParser<DoCheck>::parse(Variant* v) {
+    auto parse_rank_value = [](const std::string& value, int& out) {
+        std::stringstream ss(value);
+        int i;
+        ss >> i;
+        if (ss.fail())
+            return false;
+        out = i;
+        return true;
+    };
+    auto parse_file_value = [](const std::string& value, int& out) {
+        std::string trimmed = trim(value);
+        if (trimmed.empty())
+            return false;
+        std::stringstream ss(trimmed);
+        if (isdigit(ss.peek()))
+        {
+            int i;
+            ss >> i;
+            if (ss.fail())
+                return false;
+            out = i - 1;
+            return true;
+        }
+        char c;
+        ss >> c;
+        if (ss.fail())
+            return false;
+        out = tolower(c) - 'a';
+        return true;
+    };
+    int cfgMaxRank = -1;
+    int cfgMaxFile = -1;
+    auto itRank = config.find("maxRank");
+    if (itRank != config.end())
+        parse_rank_value(itRank->second, cfgMaxRank);
+    auto itFile = config.find("maxFile");
+    if (itFile != config.end())
+        parse_file_value(itFile->second, cfgMaxFile);
+    if (   (cfgMaxRank > 0 && cfgMaxRank - 1 > RANK_MAX)
+        || (cfgMaxFile >= 0 && cfgMaxFile > FILE_MAX))
+    {
+        v->maxRank = static_cast<Rank>(RANK_MAX + 1);
+        v->maxFile = static_cast<File>(FILE_MAX + 1);
+        return v;
+    }
+
     parse_attribute("maxRank", v->maxRank);
     parse_attribute("maxFile", v->maxFile);
     // piece types

--- a/src/parser.h
+++ b/src/parser.h
@@ -51,7 +51,7 @@ public:
 private:
     Config config;
     template <bool Current = true, class T> bool parse_attribute(const std::string& key, T& target);
-    template <bool Current = true, class T> bool parse_attribute(const std::string& key, T& target, std::string pieceToChar);
+    template <bool Current = true, class T> bool parse_attribute(const std::string& key, T& target, const Variant* v);
 };
 
 } // namespace Stockfish

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -69,9 +69,12 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
           if (pos.state()->wallSquares & make_square(f, r))
               os << " | *";
           else if (pos.unpromoted_piece_on(make_square(f, r)))
-              os << " |+" << pos.piece_to_char()[pos.unpromoted_piece_on(make_square(f, r))];
+              os << " |+" << pos.piece_symbol(pos.unpromoted_piece_on(make_square(f, r)));
           else
-              os << " | " << pos.piece_to_char()[pos.piece_on(make_square(f, r))];
+          {
+              const std::string& symbol = pos.piece_symbol(pos.piece_on(make_square(f, r)));
+              os << " | " << (symbol.empty() ? " " : symbol);
+          }
 
       os << " |" << (1 + r);
       if (r == pos.max_rank() || r == RANK_1)
@@ -85,7 +88,8 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
           {
               os << " [";
               for (PieceType pt = KING; pt >= PAWN; --pt)
-                  os << std::string(pos.count_in_hand(c, pt), pos.piece_to_char()[make_piece(c, pt)]);
+                  for (int i = 0; i < pos.count_in_hand(c, pt); ++i)
+                      os << pos.piece_symbol(make_piece(c, pt));
               os << "]";
           }
       }
@@ -279,6 +283,16 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
 
   Rank r = max_rank();
   Square sq = SQ_A1 + r * NORTH;
+  auto read_symbol = [&](char first) {
+      std::string symbol(1, first);
+      if (Variant::is_piece_id_suffix(ss.peek()))
+      {
+          char suffix;
+          ss >> suffix;
+          symbol.push_back(suffix);
+      }
+      return symbol;
+  };
 
   // 1. Piece placement
   while ((ss >> token) && !isspace(token))
@@ -318,20 +332,37 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
           ++sq;
       }
 
-      else if ((idx = piece_to_char().find(token)) != string::npos || (idx = piece_to_char_synonyms().find(token)) != string::npos)
+      else if (Variant::is_piece_id_start(token))
       {
-          if (ss.peek() == '~')
-              ss >> token;
-          put_piece(Piece(idx), sq, token == '~');
-          ++sq;
+          std::string symbol = read_symbol(token);
+          Piece pc = piece_from_symbol(symbol);
+          if (pc != NO_PIECE)
+          {
+              bool promoted = false;
+              if (ss.peek() == '~')
+              {
+                  ss >> token;
+                  promoted = true;
+              }
+              put_piece(pc, sq, promoted);
+              ++sq;
+          }
       }
 
       // Promoted shogi pieces
-      else if (token == '+' && (idx = piece_to_char().find(ss.peek())) != string::npos && promoted_piece_type(type_of(Piece(idx))))
+      else if (token == '+')
       {
-          ss >> token;
-          put_piece(make_piece(color_of(Piece(idx)), promoted_piece_type(type_of(Piece(idx)))), sq, true, Piece(idx));
-          ++sq;
+          if (Variant::is_piece_id_start(ss.peek()))
+          {
+              ss >> token;
+              std::string symbol = read_symbol(token);
+              Piece pc = piece_from_symbol(symbol);
+              if (pc != NO_PIECE && promoted_piece_type(type_of(pc)))
+              {
+                  put_piece(make_piece(color_of(pc), promoted_piece_type(type_of(pc))), sq, true, pc);
+                  ++sq;
+              }
+          }
       }
   }
   // Pieces in hand
@@ -340,8 +371,13 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
       {
           if (token == ']')
               continue;
-          else if ((idx = piece_to_char().find(token)) != string::npos)
-              add_to_hand(Piece(idx));
+          else if (Variant::is_piece_id_start(token))
+          {
+              std::string symbol = read_symbol(token);
+              Piece pc = piece_from_symbol(symbol);
+              if (pc != NO_PIECE)
+                  add_to_hand(pc);
+          }
       }
 
   // 2. Active color
@@ -500,10 +536,13 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
               while (isdigit(ss.peek()) && ss >> token)
                   handCount = 10 * handCount + (token - '0');
           }
-          else if ((idx = piece_to_char().find(token)) != string::npos)
+          else if (Variant::is_piece_id_start(token))
           {
-              for (int i = 0; i < handCount; i++)
-                  add_to_hand(Piece(idx));
+              std::string symbol = read_symbol(token);
+              Piece pc = piece_from_symbol(symbol);
+              if (pc != NO_PIECE)
+                  for (int i = 0; i < handCount; i++)
+                      add_to_hand(pc);
               handCount = 1;
           }
       }
@@ -698,6 +737,11 @@ string Position::fen(bool sfen, bool showPromoted, int countStarted, std::string
 
   int emptyCnt;
   std::ostringstream ss;
+  auto append_piece_symbols = [&](Piece pc, int count) {
+      const std::string& symbol = piece_symbol(pc);
+      for (int i = 0; i < count; ++i)
+          ss << symbol;
+  };
 
   for (Rank r = max_rank(); r >= RANK_1; --r)
   {
@@ -716,10 +760,10 @@ string Position::fen(bool sfen, bool showPromoted, int countStarted, std::string
                   ss << "*";
               else if (unpromoted_piece_on(make_square(f, r)))
                   // Promoted shogi pieces, e.g., +r for dragon
-                  ss << "+" << piece_to_char()[unpromoted_piece_on(make_square(f, r))];
+                  ss << "+" << piece_symbol(unpromoted_piece_on(make_square(f, r)));
               else
               {
-                  ss << piece_to_char()[piece_on(make_square(f, r))];
+                  ss << piece_symbol(piece_on(make_square(f, r)));
 
                   // Set promoted pieces
                   if (((captures_to_hand() && !drop_loop()) || two_boards() ||  showPromoted) && is_promoted(make_square(f, r)))
@@ -742,7 +786,7 @@ string Position::fen(bool sfen, bool showPromoted, int countStarted, std::string
               {
                   if (pieceCountInHand[c][pt] > 1)
                       ss << pieceCountInHand[c][pt];
-                  ss << piece_to_char()[make_piece(c, pt)];
+                  ss << piece_symbol(make_piece(c, pt));
               }
       if (count_in_hand(ALL_PIECES) == 0)
           ss << '-';
@@ -761,7 +805,7 @@ string Position::fen(bool sfen, bool showPromoted, int countStarted, std::string
               for (PieceType pt = KING; pt >= PAWN; --pt)
               {
                   assert(pieceCountInHand[c][pt] >= 0);
-                  ss << std::string(pieceCountInHand[c][pt], piece_to_char()[make_piece(c, pt)]);
+                  append_piece_symbols(make_piece(c, pt), pieceCountInHand[c][pt]);
               }
       ss << ']';
   }
@@ -1125,7 +1169,7 @@ bool Position::legal(Move m) const {
       if (walling_rule() == DUCK)
           occupied ^= st->wallSquares;
       if (walling() || is_gating(m))
-          occupied |= gating_square(m);
+          occupied |= gate_square(m);
       if (type_of(m) == CASTLING)
       {
           // After castling, the rook and king final positions are the same in
@@ -1241,7 +1285,7 @@ bool Position::legal(Move m) const {
 
       // Will the gate be blocked by king or rook?
       Square rto = to + (to_sq(m) > from_sq(m) ? WEST : EAST);
-      if (is_gating(m) && (gating_square(m) == to || gating_square(m) == rto))
+      if (is_gating(m) && (gate_square(m) == to || gate_square(m) == rto))
           return false;
 
       // Non-royal pieces can not be impeded from castling
@@ -1332,14 +1376,14 @@ bool Position::pseudo_legal(const Move m) const {
       Bitboard wallsquares = st->wallSquares;
 
       // Illegal wall square placement
-      if (!((board_bb() & ~((pieces() ^ from) | to)) & gating_square(m)))
+      if (!((board_bb() & ~((pieces() ^ from) | to)) & gate_square(m)))
           return false;
-      if (!(var->wallingRegion[us] & gating_square(m)) || //putting a wall on disallowed square
-          wallsquares & gating_square(m)) //or square already with a wall
+      if (!(var->wallingRegion[us] & gate_square(m)) || //putting a wall on disallowed square
+          wallsquares & gate_square(m)) //or square already with a wall
           return false;
-      if (walling_rule() == ARROW && !(moves_bb(us, type_of(pc), to, pieces() ^ from) & gating_square(m)))
+      if (walling_rule() == ARROW && !(moves_bb(us, type_of(pc), to, pieces() ^ from) & gate_square(m)))
           return false;
-      if (walling_rule() == PAST && (from != gating_square(m)))
+      if (walling_rule() == PAST && (from != gate_square(m)))
           return false;
       if (walling_rule() == EDGE)
       {
@@ -1347,7 +1391,7 @@ bool Position::pseudo_legal(const Move m) const {
                   ((FileABB | file_bb(max_file()) | Rank1BB | rank_bb(max_rank())) |
                   ( shift<NORTH     >(wallsquares) | shift<SOUTH     >(wallsquares)
                   | shift<EAST      >(wallsquares) | shift<WEST      >(wallsquares)));
-          if (!(validsquares & gating_square(m))) return false;
+          if (!(validsquares & gate_square(m))) return false;
       };
   }
 
@@ -1470,7 +1514,7 @@ bool Position::gives_check(Move m) const {
 
   // Is there a check by gated pieces?
   if (    is_gating(m)
-      && attacks_bb(sideToMove, gating_type(m), gating_square(m), (pieces() ^ from) | to) & square<KING>(~sideToMove))
+      && attacks_bb(sideToMove, gating_type(m), gate_square(m), (pieces() ^ from) | to) & square<KING>(~sideToMove))
       return true;
 
   // Petrified piece can't give check
@@ -1856,7 +1900,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       {
           if (   (var->enPassantRegion[them] & (to - pawn_push(us)))
               && ((pawn_attacks_bb(us, to - pawn_push(us)) & pieces(them, PAWN)) || var->enPassantTypes[them] & ~piece_set(PAWN))
-              && !(walling() && gating_square(m) == to - pawn_push(us)))
+              && !(walling() && gate_square(m) == to - pawn_push(us)))
           {
               st->epSquares |= to - pawn_push(us);
               k ^= Zobrist::enpassant[file_of(to)];
@@ -1864,7 +1908,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           if (   std::abs(int(to) - int(from)) == 3 * NORTH
               && (var->enPassantRegion[them] & (to - 2 * pawn_push(us)))
               && ((pawn_attacks_bb(us, to - 2 * pawn_push(us)) & pieces(them, PAWN)) || var->enPassantTypes[them] & ~piece_set(PAWN))
-              && !(walling() && gating_square(m) == to - 2 * pawn_push(us)))
+              && !(walling() && gate_square(m) == to - 2 * pawn_push(us)))
           {
               st->epSquares |= to - 2 * pawn_push(us);
               k ^= Zobrist::enpassant[file_of(to)];
@@ -1945,7 +1989,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Add gating piece
   if (is_gating(m))
   {
-      Square gate = gating_square(m);
+      Square gate = gate_square(m);
       Piece gating_piece = make_piece(us, gating_type(m));
 
       if (Eval::NNUE::useNNUE != Eval::NNUE::UseNNUEMode::False)
@@ -2081,9 +2125,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
               k ^= Zobrist::wall[pop_lsb(b)];
           st->wallSquares = 0;
       }
-      st->wallSquares |= gating_square(m);
-      byTypeBB[ALL_PIECES] |= gating_square(m);
-      k ^= Zobrist::wall[gating_square(m)];
+      st->wallSquares |= gate_square(m);
+      byTypeBB[ALL_PIECES] |= gate_square(m);
+      k ^= Zobrist::wall[gate_square(m)];
   }
 
   // Update the key with the final value
@@ -2186,10 +2230,10 @@ void Position::undo_move(Move m) {
   if (is_gating(m))
   {
       Piece gating_piece = make_piece(us, gating_type(m));
-      remove_piece(gating_square(m));
-      board[gating_square(m)] = NO_PIECE;
+      remove_piece(gate_square(m));
+      board[gate_square(m)] = NO_PIECE;
       add_to_hand(gating_piece);
-      st->gatesBB[us] |= gating_square(m);
+      st->gatesBB[us] |= gate_square(m);
   }
 
   if (type_of(m) == PROMOTION)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -269,7 +269,7 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
       incremented after Black's move.
 */
 
-  unsigned char col, row, token;
+  unsigned char token;
   std::istringstream ss(fenStr);
 
   std::memset(this, 0, sizeof(Position));

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -349,7 +349,7 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
       }
 
       // Promoted shogi pieces
-      else if (token == '+')
+      else if (token == '+' && var->shogiStylePromotions)
       {
           if (Variant::is_piece_id_start(ss.peek()))
           {
@@ -469,33 +469,55 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
       // 4. En passant square.
       // Ignore if square is invalid or not on side to move relative rank 6.
       else
-          while (   ((ss >> col) && (col >= 'a' && col <= 'a' + max_file()))
-                 && ((ss >> row) && (row >= '1' && row <= '1' + max_rank())))
+      {
+          std::string epInfo;
+          ss >> std::skipws >> epInfo;
+          ss >> std::noskipws;
+          if (!epInfo.empty() && epInfo != "-")
           {
-              Square epSquare = make_square(File(col - 'a'), Rank(row - '1'));
+              size_t i = 0;
+              while (i < epInfo.size())
+              {
+                  char fileChar = epInfo[i];
+                  if (fileChar < 'a' || fileChar > 'a' + max_file())
+                      break;
+                  ++i;
+                  if (i >= epInfo.size() || !isdigit(epInfo[i]))
+                      break;
+                  int rankNum = 0;
+                  while (i < epInfo.size() && isdigit(epInfo[i]))
+                  {
+                      rankNum = rankNum * 10 + (epInfo[i] - '0');
+                      ++i;
+                  }
+                  if (rankNum < 1 || rankNum > int(max_rank()) + 1)
+                      continue;
+                  Square epSquare = make_square(File(fileChar - 'a'), Rank(rankNum - 1));
 #ifdef LARGEBOARDS
-              // Consider different rank numbering in CECP
-              if (max_rank() == RANK_10 && CurrentProtocol == XBOARD)
-                  epSquare += NORTH;
+                  // Consider different rank numbering in CECP
+                  if (max_rank() == RANK_10 && CurrentProtocol == XBOARD)
+                      epSquare += NORTH;
 #endif
 
-              // En passant square will be considered only if
-              // epSquare is within enPassantRegion and
-              // 1) variant has non-standard rules
-              // or
-              // 2)
-              // a) side to move have a pawn threatening epSquare
-              // b) there is an enemy pawn one or two (for triple steps) squares in front of epSquare
-              // c) there is no (non-wall) piece on epSquare or behind epSquare
-              if (   (var->enPassantRegion[sideToMove] & epSquare)
-                  && (   !var->fastAttacks
-                      || (var->enPassantTypes[sideToMove] & ~piece_set(PAWN))
-                      || (   pawn_attacks_bb(~sideToMove, epSquare) & pieces(sideToMove, PAWN)
-                          && (   (pieces(~sideToMove, PAWN) & (epSquare + pawn_push(~sideToMove)))
-                              || (pieces(~sideToMove, PAWN) & (epSquare + 2 * pawn_push(~sideToMove))))
-                          && !((pieces(WHITE) | pieces(BLACK)) & (epSquare | (epSquare + pawn_push(sideToMove)))))))
-                  st->epSquares |= epSquare;
+                  // En passant square will be considered only if
+                  // epSquare is within enPassantRegion and
+                  // 1) variant has non-standard rules
+                  // or
+                  // 2)
+                  // a) side to move have a pawn threatening epSquare
+                  // b) there is an enemy pawn one or two (for triple steps) squares in front of epSquare
+                  // c) there is no (non-wall) piece on epSquare or behind epSquare
+                  if (   (var->enPassantRegion[sideToMove] & epSquare)
+                      && (   !var->fastAttacks
+                          || (var->enPassantTypes[sideToMove] & ~piece_set(PAWN))
+                          || (   pawn_attacks_bb(~sideToMove, epSquare) & pieces(sideToMove, PAWN)
+                              && (   (pieces(~sideToMove, PAWN) & (epSquare + pawn_push(~sideToMove)))
+                                  || (pieces(~sideToMove, PAWN) & (epSquare + 2 * pawn_push(~sideToMove))))
+                              && !((pieces(WHITE) | pieces(BLACK)) & (epSquare | (epSquare + pawn_push(sideToMove)))))))
+                      st->epSquares |= epSquare;
+              }
           }
+      }
   }
 
   // Check counter for nCheck

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -270,7 +270,6 @@ Position& Position::set(const Variant* v, const string& fenStr, bool isChess960,
 */
 
   unsigned char col, row, token;
-  size_t idx;
   std::istringstream ss(fenStr);
 
   std::memset(this, 0, sizeof(Position));

--- a/src/position.h
+++ b/src/position.h
@@ -131,6 +131,10 @@ public:
   PieceSet piece_types() const;
   const std::string& piece_to_char() const;
   const std::string& piece_to_char_synonyms() const;
+  const std::string& piece_symbol(Piece pc) const;
+  const std::string& piece_symbol_synonym(Piece pc) const;
+  Piece piece_from_symbol(const std::string& token) const;
+  PieceType piece_type_from_symbol(const std::string& token) const;
   Bitboard promotion_zone(Color c) const;
   Square promotion_square(Color c, Square s) const;
   PieceType main_promotion_pawn_type(Color c) const;
@@ -251,6 +255,7 @@ public:
   Bitboard ep_squares() const;
   Square castling_king_square(Color c) const;
   Bitboard gates(Color c) const;
+  Square gate_square(Move m) const;
   bool empty(Square s) const;
   int count(Color c, PieceType pt) const;
   template<PieceType Pt> int count(Color c) const;
@@ -470,6 +475,26 @@ inline const std::string& Position::piece_to_char() const {
 inline const std::string& Position::piece_to_char_synonyms() const {
   assert(var != nullptr);
   return var->pieceToCharSynonyms;
+}
+
+inline const std::string& Position::piece_symbol(Piece pc) const {
+  assert(var != nullptr);
+  return var->piece_symbol(pc);
+}
+
+inline const std::string& Position::piece_symbol_synonym(Piece pc) const {
+  assert(var != nullptr);
+  return var->piece_symbol_synonym(pc);
+}
+
+inline Piece Position::piece_from_symbol(const std::string& token) const {
+  assert(var != nullptr);
+  return var->piece_from_symbol(token);
+}
+
+inline PieceType Position::piece_type_from_symbol(const std::string& token) const {
+  assert(var != nullptr);
+  return var->piece_type_from_symbol(token);
 }
 
 inline Bitboard Position::promotion_zone(Color c) const {
@@ -1282,6 +1307,24 @@ inline Bitboard Position::gates(Color c) const {
   return st->gatesBB[c];
 }
 
+inline Square Position::gate_square(Move m) const {
+  if (seirawan_gating() && is_gating(m))
+  {
+      Square from = from_sq(m);
+      if (type_of(m) != CASTLING)
+          return from;
+      Square to = to_sq(m);
+      const unsigned mask = (1u << PIECE_TYPE_BITS) - 1u;
+      const unsigned gate_bits = static_cast<unsigned>(gating_square(m)) & mask;
+      if ((static_cast<unsigned>(from) & mask) == gate_bits)
+          return from;
+      if ((static_cast<unsigned>(to) & mask) == gate_bits)
+          return to;
+      return from;
+  }
+  return gating_square(m);
+}
+
 inline bool Position::is_on_semiopen_file(Color c, Square s) const {
   return !((pieces(c, PAWN) | pieces(c, SHOGI_PAWN, SOLDIER)) & file_bb(s));
 }
@@ -1525,7 +1568,7 @@ inline const std::string Position::piece_to_partner() const {
   Piece piece = st->capturedpromoted ?
       (st->unpromotedCapturedPiece ? st->unpromotedCapturedPiece : make_piece(color, main_promotion_pawn_type(color))) :
       st->capturedPiece;
-  return std::string(1, piece_to_char()[piece]);
+  return piece_symbol(piece);
 }
 
 inline Thread* Position::this_thread() const {

--- a/src/position.h
+++ b/src/position.h
@@ -1314,12 +1314,9 @@ inline Square Position::gate_square(Move m) const {
       if (type_of(m) != CASTLING)
           return from;
       Square to = to_sq(m);
-      const unsigned mask = (1u << PIECE_TYPE_BITS) - 1u;
-      const unsigned gate_bits = static_cast<unsigned>(gating_square(m)) & mask;
-      if ((static_cast<unsigned>(from) & mask) == gate_bits)
-          return from;
-      if ((static_cast<unsigned>(to) & mask) == gate_bits)
-          return to;
+      Square gate = gating_square(m);
+      if (gate == from || gate == to)
+          return gate;
       return from;
   }
   return gating_square(m);

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -304,6 +304,7 @@ void init(const Variant* v) {
 
       // Determine pawn rank
       std::istringstream ss(v->startFen);
+      ss >> std::noskipws;
       unsigned char token;
       Rank rc = v->maxRank;
       Rank pawnRank = RANK_2;
@@ -311,8 +312,18 @@ void init(const Variant* v) {
       {
           if (token == '/')
               --rc;
-          else if (token == v->pieceToChar[PAWN] || token == v->pieceToChar[SHOGI_PAWN])
-              pawnRank = rc;
+          else if (Variant::is_piece_id_start(token))
+          {
+              std::string symbol(1, char(token));
+              if (Variant::is_piece_id_suffix(ss.peek()))
+              {
+                  ss >> token;
+                  symbol.push_back(char(token));
+              }
+              PieceType ptFen = v->piece_type_from_symbol(symbol);
+              if (ptFen == PAWN || ptFen == SHOGI_PAWN)
+                  pawnRank = rc;
+          }
       }
 
       for (Square s = SQ_A1; s <= SQ_MAX; ++s)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -461,6 +461,7 @@ void Thread::search() {
               if (   mainThread
                   && multiPV == 1
                   && (bestValue <= alpha || bestValue >= beta)
+                  && (Limits.use_time_management() || Limits.movetime)
                   && Time.elapsed() > 3000)
                   sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
 
@@ -492,7 +493,9 @@ void Thread::search() {
           std::stable_sort(rootMoves.begin() + pvFirst, rootMoves.begin() + pvIdx + 1);
 
           if (    mainThread
-              && (Threads.stop || pvIdx + 1 == multiPV || Time.elapsed() > 3000))
+              && (   Threads.stop
+                  || pvIdx + 1 == multiPV
+                  || ((Limits.use_time_management() || Limits.movetime) && Time.elapsed() > 3000)))
               sync_cout << UCI::pv(rootPos, rootDepth, alpha, beta) << sync_endl;
       }
 
@@ -801,7 +804,7 @@ namespace {
                 int penalty = -stat_bonus(depth);
                 thisThread->mainHistory[us][from_to(ttMove)] << penalty;
                 if (pos.walling())
-                    thisThread->gateHistory[us][gating_square(ttMove)] << penalty;
+                    thisThread->gateHistory[us][pos.gate_square(ttMove)] << penalty;
                 update_continuation_histories(ss, pos.moved_piece(ttMove), to_sq(ttMove), penalty);
             }
         }
@@ -1326,7 +1329,7 @@ moves_loop: // When in check, search starts from here
                   r++;
 
               ss->statScore =  thisThread->mainHistory[us][from_to(move)]
-                             + thisThread->gateHistory[us][gating_square(move)] * 2
+                             + thisThread->gateHistory[us][pos.gate_square(move)] * 2
                              + (*contHist[0])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[1])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[3])[history_slot(movedPiece)][to_sq(move)]
@@ -1831,7 +1834,7 @@ moves_loop: // When in check, search starts from here
             if (!(pos.walling() && from_to(quietsSearched[i]) == from_to(bestMove)))
                 thisThread->mainHistory[us][from_to(quietsSearched[i])] << -bonus2;
             if (pos.walling())
-                thisThread->gateHistory[us][gating_square(quietsSearched[i])] << -bonus2;
+                thisThread->gateHistory[us][pos.gate_square(quietsSearched[i])] << -bonus2;
             update_continuation_histories(ss, pos.moved_piece(quietsSearched[i]), to_sq(quietsSearched[i]), -bonus2);
         }
     }
@@ -1840,7 +1843,7 @@ moves_loop: // When in check, search starts from here
         // Increase stats for the best move in case it was a capture move
         captureHistory[moved_piece][to_sq(bestMove)][captured] << bonus1;
         if (pos.walling())
-            thisThread->gateHistory[us][gating_square(bestMove)] << bonus1;
+            thisThread->gateHistory[us][pos.gate_square(bestMove)] << bonus1;
     }
 
     // Extra penalty for a quiet early move that was not a TT move or
@@ -1857,7 +1860,7 @@ moves_loop: // When in check, search starts from here
         if (!(pos.walling() && from_to(capturesSearched[i]) == from_to(bestMove)))
             captureHistory[moved_piece][to_sq(capturesSearched[i])][captured] << -bonus1;
         if (pos.walling())
-            thisThread->gateHistory[us][gating_square(capturesSearched[i])] << -bonus1;
+            thisThread->gateHistory[us][pos.gate_square(capturesSearched[i])] << -bonus1;
     }
   }
 
@@ -1893,7 +1896,7 @@ moves_loop: // When in check, search starts from here
     Thread* thisThread = pos.this_thread();
     thisThread->mainHistory[us][from_to(move)] << bonus;
     if (pos.walling())
-        thisThread->gateHistory[us][gating_square(move)] << bonus;
+        thisThread->gateHistory[us][pos.gate_square(move)] << bonus;
     update_continuation_histories(ss, pos.moved_piece(move), to_sq(move), bonus);
 
     // Penalty for reversed move in case of moved piece not being a pawn

--- a/src/tools/packed_sfen.h
+++ b/src/tools/packed_sfen.h
@@ -11,7 +11,9 @@ namespace Stockfish::Tools {
     // packed sfen
     struct PackedSfen { std::uint8_t data[DATA_SIZE / 8]; };
 
-    #if defined(LARGEBOARDS)
+    #if defined(VERY_LARGE_BOARDS)
+    using PackedMove = std::uint64_t;
+    #elif defined(LARGEBOARDS)
     using PackedMove = std::uint32_t;
     #else
     using PackedMove = std::uint16_t;

--- a/src/tools/packed_sfen.h
+++ b/src/tools/packed_sfen.h
@@ -4,10 +4,18 @@
 #include <vector>
 #include <cstdint>
 
+#include "types.h"
+
 namespace Stockfish::Tools {
 
     // packed sfen
     struct PackedSfen { std::uint8_t data[DATA_SIZE / 8]; };
+
+    #if defined(LARGEBOARDS)
+    using PackedMove = std::uint32_t;
+    #else
+    using PackedMove = std::uint16_t;
+    #endif
 
     // Structure in which PackedSfen and evaluation value are integrated
     // If you write different contents for each option, it will be a problem when reusing the teacher game
@@ -17,12 +25,12 @@ namespace Stockfish::Tools {
         // phase
         PackedSfen sfen;
 
-        // Evaluation value returned from Tools::search()
-        std::int16_t score;
-
         // PV first move
         // Used when finding the match rate with the teacher
-        std::uint16_t move;
+        PackedMove move;
+
+        // Evaluation value returned from Tools::search()
+        std::int16_t score;
 
         // Trouble of the phase from the initial phase.
         std::uint16_t gamePly;
@@ -37,7 +45,7 @@ namespace Stockfish::Tools {
         //Because this structure size is not fixed, pad it so that it is 72 bytes in any environment.
         std::uint8_t padding;
 
-        // 64 + 2 + 2 + 2 + 1 + 1 = 72bytes
+        // DATA_SIZE / 8 + sizeof(score) + sizeof(move) + sizeof(gamePly) + 2 = bytes
     };
 
     // Phase array: PSVector stands for packed sfen vector.

--- a/src/tools/puzzle_generator.cpp
+++ b/src/tools/puzzle_generator.cpp
@@ -404,7 +404,7 @@ namespace Stockfish::Tools
                         if (pt == KING || int(prng.rand(PieceValue[EG][pt])) > 20 + (pos.variant()->nnueMaxPieces / 2 - pos.count<ALL_PIECES>() - pos.count_in_hand(ALL_PIECES)))
                             continue;
                         for (Color c : { WHITE, BLACK })
-                            fen.insert(fen.find(']'), 1, pos.piece_to_char()[make_piece(c, pt)]);
+                            fen.insert(fen.find(']'), pos.piece_symbol(make_piece(c, pt)));
                     }
                     pos.set(variants.find(Options["UCI_Variant"])->second, fen, false, &si, &th);
                 }

--- a/src/tools/sfen_packer.cpp
+++ b/src/tools/sfen_packer.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <fstream>
 #include <cstring> // std::memset()
+#include <bitset>
 
 using namespace std;
 
@@ -103,6 +104,10 @@ namespace Stockfish::Tools {
         uint8_t *data; // uint8_t[32];
 
         BitStream stream;
+        bool use_wide = false;
+        int square_bits = 0;
+        int piece_bits = 0;
+        int pocket_bits = 0;
 
         // Output the board pieces to stream.
         void write_board_piece_to_stream(const Position& pos, Piece pc);
@@ -162,6 +167,46 @@ namespace Stockfish::Tools {
         {0b11111,5}, //
     };
 
+    constexpr int bits_needed(unsigned int value) {
+        int bits = 0;
+        while ((1u << bits) <= value && bits < 31)
+            ++bits;
+        return bits ? bits : 1;
+    }
+
+    inline int square_count(const Position& pos) {
+        return pos.files() * pos.ranks();
+    }
+
+    inline int piece_type_count(const Position& pos) {
+        return static_cast<int>(std::bitset<64>(pos.piece_types()).count());
+    }
+
+    inline bool use_wide_sfen(const Position& pos) {
+        return square_count(pos) > 128 || piece_type_count(pos) > 16;
+    }
+
+    inline int square_bits_for(const Position& pos) {
+        return bits_needed(static_cast<unsigned int>(square_count(pos) - 1));
+    }
+
+    inline int piece_bits_for(const Position& pos) {
+        return bits_needed(static_cast<unsigned int>(2 * piece_type_count(pos)));
+    }
+
+    inline int pocket_bits_for(const Position& pos) {
+        return use_wide_sfen(pos) ? bits_needed(static_cast<unsigned int>(pos.variant()->nnueMaxPieces))
+                                  : (DATA_SIZE > 512 ? 7 : 5);
+    }
+
+    inline int king_bits_for(const Position& pos) {
+        return use_wide_sfen(pos) ? square_bits_for(pos) : 7;
+    }
+
+    inline int ep_bits_for(const Position& pos) {
+        return use_wide_sfen(pos) ? square_bits_for(pos) : 7;
+    }
+
     inline Square to_variant_square(Square s, const Position& pos) {
         return Square(s - rank_of(s) * (FILE_MAX - pos.max_file()));
     }
@@ -173,8 +218,14 @@ namespace Stockfish::Tools {
     // Pack sfen and store in data[64].
     void SfenPacker::pack(const Position& pos)
     {
-        memset(data, 0, DATA_SIZE / 8 /* 512bit */);
+        memset(data, 0, DATA_SIZE / 8 /* DATA_SIZE bits */);
         stream.set_data(data);
+        use_wide = use_wide_sfen(pos);
+        square_bits = square_bits_for(pos);
+        piece_bits = piece_bits_for(pos);
+        pocket_bits = pocket_bits_for(pos);
+        const int king_bits = king_bits_for(pos);
+        const int ep_bits = ep_bits_for(pos);
 
         // turn
         // Side to move.
@@ -183,7 +234,8 @@ namespace Stockfish::Tools {
         // 7-bit positions for leading and trailing balls
         // White king and black king, 6 bits for each.
         for(auto c: Colors)
-            stream.write_n_bit(pos.nnue_king() ? to_variant_square(pos.king_square(c), pos) : (pos.max_file() + 1) * (pos.max_rank() + 1), 7);
+            stream.write_n_bit(pos.nnue_king() ? to_variant_square(pos.king_square(c), pos)
+                                               : (pos.max_file() + 1) * (pos.max_rank() + 1), king_bits);
 
         // Write the pieces on the board other than the kings.
         for (Rank r = pos.max_rank(); r >= RANK_1; --r)
@@ -199,7 +251,7 @@ namespace Stockfish::Tools {
 
         for(auto c: Colors)
             for (PieceSet ps = pos.piece_types(); ps;)
-                stream.write_n_bit(pos.count_in_hand(c, pop_lsb(ps)), DATA_SIZE > 512 ? 7 : 5);
+                stream.write_n_bit(pos.count_in_hand(c, pop_lsb(ps)), pocket_bits);
 
         // TODO(someone): Support chess960.
         stream.write_one_bit(pos.can_castle(WHITE_OO));
@@ -213,7 +265,7 @@ namespace Stockfish::Tools {
         else {
             stream.write_one_bit(1);
             // Additional ep squares (e.g., for berolina) are not encoded
-            stream.write_n_bit(static_cast<int>(to_variant_square(lsb(pos.ep_squares()), pos)), 7);
+            stream.write_n_bit(static_cast<int>(to_variant_square(lsb(pos.ep_squares()), pos)), ep_bits);
         }
 
         stream.write_n_bit(pos.state()->rule50, 6);
@@ -237,6 +289,18 @@ namespace Stockfish::Tools {
     // Output the board pieces to stream.
     void SfenPacker::write_board_piece_to_stream(const Position& pos, Piece pc)
     {
+        if (use_wide)
+        {
+            int code = 0;
+            if (pc != NO_PIECE)
+            {
+                int idx = pos.variant()->pieceIndex[type_of(pc)];
+                code = 1 + idx * 2 + (color_of(pc) == BLACK);
+            }
+            stream.write_n_bit(code, piece_bits);
+            return;
+        }
+
         // piece type
         PieceType pr = PieceType(pc == NO_PIECE ? NO_PIECE_TYPE : pos.variant()->pieceIndex[type_of(pc)] + 1);
         auto c = huffman_table[pr];
@@ -252,6 +316,24 @@ namespace Stockfish::Tools {
     // Read one board piece from stream
     Piece SfenPacker::read_board_piece_from_stream(const Position& pos)
     {
+        if (use_wide)
+        {
+            int code = stream.read_n_bit(piece_bits);
+            if (code == 0)
+                return NO_PIECE;
+
+            Color c = (code - 1) & 1 ? BLACK : WHITE;
+            int idx = (code - 1) >> 1;
+            for (PieceSet ps = pos.piece_types(); ps;)
+            {
+                PieceType pt = pop_lsb(ps);
+                if (pos.variant()->pieceIndex[pt] == idx)
+                    return make_piece(c, pt);
+            }
+            assert(false);
+            return NO_PIECE;
+        }
+
         PieceType pr = NO_PIECE_TYPE;
         int code = 0, bits = 0;
         while (true)
@@ -298,6 +380,12 @@ namespace Stockfish::Tools {
         si->accumulator.computed[BLACK] = false;
         pos.st = si;
         pos.var = variants.find(Options["UCI_Variant"])->second;
+        packer.use_wide = use_wide_sfen(pos);
+        packer.square_bits = square_bits_for(pos);
+        packer.piece_bits = piece_bits_for(pos);
+        packer.pocket_bits = pocket_bits_for(pos);
+        const int king_bits = king_bits_for(pos);
+        const int ep_bits = ep_bits_for(pos);
 
         // Active color
         pos.sideToMove = (Color)stream.read_one_bit();
@@ -305,7 +393,7 @@ namespace Stockfish::Tools {
         // First the position of the ball
         for (auto c : Colors)
         {
-            Square king_sq = from_variant_square(Square(stream.read_n_bit(7)), pos);
+            Square king_sq = from_variant_square(Square(stream.read_n_bit(king_bits)), pos);
             if (pos.nnue_king())
                 pos.board[king_sq] = make_piece(c, pos.nnue_king());
         }
@@ -337,7 +425,7 @@ namespace Stockfish::Tools {
 
                 pos.put_piece(Piece(pc), sq);
 
-                if (stream.get_cursor()> 512)
+                if (stream.get_cursor() > DATA_SIZE)
                     return 1;
             }
         }
@@ -347,7 +435,7 @@ namespace Stockfish::Tools {
             for (PieceSet ps = pos.piece_types(); ps;)
             {
                 PieceType pt = pop_lsb(ps);
-                int count = stream.read_n_bit(DATA_SIZE > 512 ? 7 : 5);
+                int count = stream.read_n_bit(packer.pocket_bits);
                 for (int i = 0; i < count; ++i)
                     pos.add_to_hand(make_piece(c, pt));
             }
@@ -378,7 +466,7 @@ namespace Stockfish::Tools {
 
         // En passant square.
         if (stream.read_one_bit()) {
-            Square ep_square = static_cast<Square>(stream.read_n_bit(7));
+            Square ep_square = static_cast<Square>(stream.read_n_bit(ep_bits));
             pos.st->epSquares = square_bb(ep_square);
         }
         else {

--- a/src/tools/training_data_generator.cpp
+++ b/src/tools/training_data_generator.cpp
@@ -409,7 +409,7 @@ namespace Stockfish::Tools
                         if (pt == KING || int(prng.rand(PieceValue[EG][pt])) > 20 + (pos.variant()->nnueMaxPieces / 2 - pos.count<ALL_PIECES>() - pos.count_in_hand(ALL_PIECES)))
                             continue;
                         for (Color c : { WHITE, BLACK })
-                            fen.insert(fen.find(']'), 1, pos.piece_to_char()[make_piece(c, pt)]);
+                            fen.insert(fen.find(']'), pos.piece_symbol(make_piece(c, pt)));
                     }
                     pos.set(variants.find(Options["UCI_Variant"])->second, fen, false, &si, &th);
                 }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -42,7 +42,7 @@ void TTEntry::save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev) 
   }
   // Preserve any existing move for the same position
   if (m || (uint16_t)k != key16)
-      move32 = (uint32_t)m;
+      move32 = static_cast<TTMove>(m);
 
   // Overwrite less valuable entries (cheapest checks first)
   if (b == BOUND_EXACT

--- a/src/tt.h
+++ b/src/tt.h
@@ -24,6 +24,12 @@
 
 namespace Stockfish {
 
+#if defined(VERY_LARGE_BOARDS)
+using TTMove = uint64_t;
+#else
+using TTMove = uint32_t;
+#endif
+
 /// TTEntry struct is the 12 bytes transposition table entry, defined as below:
 ///
 /// key        16 bit
@@ -37,7 +43,7 @@ namespace Stockfish {
 
 struct TTEntry {
 
-  Move  move()  const { return (Move )move32; }
+  Move  move()  const { return Move(move32); }
   Value value() const { return (Value)value16; }
   Value eval()  const { return (Value)eval16; }
   Depth depth() const { return (Depth)depth8 + DEPTH_OFFSET; }
@@ -51,7 +57,7 @@ private:
   uint16_t key16;
   uint8_t  depth8;
   uint8_t  genBound8;
-  uint32_t move32;
+  TTMove move32;
   int16_t  value16;
   int16_t  eval16;
 };
@@ -65,11 +71,17 @@ private:
 
 class TranspositionTable {
 
+#if defined(VERY_LARGE_BOARDS)
+  static constexpr int ClusterSize = 4;
+#else
   static constexpr int ClusterSize = 5;
+#endif
 
   struct Cluster {
     TTEntry entry[ClusterSize];
+#if !defined(VERY_LARGE_BOARDS)
     char padding[4]; // Pad to 64 bytes
+#endif
   };
 
   static_assert(sizeof(Cluster) == 64, "Unexpected Cluster size");

--- a/src/types.h
+++ b/src/types.h
@@ -204,7 +204,7 @@ struct Bitboard {
     }
 
     constexpr bool operator == (const Bitboard y) const {
-        return (b64[0] == y.b64[0]) && (b64[1] == y.b64[1]);
+        return (b64[0] == y.b64[0]) && (b64[1] == y.b64[1]) && (b64[2] == y.b64[2]) && (b64[3] == y.b64[3]);
     }
 
     constexpr bool operator != (const Bitboard y) const {
@@ -314,6 +314,123 @@ struct Bitboard {
     constexpr Bitboard() : b64 {0, 0} {}
     constexpr Bitboard(uint64_t i) : b64 {0, i} {}
     constexpr Bitboard(uint64_t hi, uint64_t lo) : b64 {hi, lo} {};
+
+    constexpr operator bool() const {
+        return b64[0] || b64[1];
+    }
+
+    constexpr operator long long unsigned () const {
+        return b64[1];
+    }
+
+    constexpr operator unsigned() const {
+        return b64[1];
+    }
+
+    constexpr Bitboard operator << (const unsigned int bits) const {
+        if (bits == 0)
+            return *this;
+        if (bits >= 128)
+            return Bitboard();
+        if (bits >= 64)
+            return Bitboard(b64[1] << (bits - 64), 0);
+        return Bitboard((b64[0] << bits) | (b64[1] >> (64 - bits)), b64[1] << bits);
+    }
+
+    constexpr Bitboard operator >> (const unsigned int bits) const {
+        if (bits == 0)
+            return *this;
+        if (bits >= 128)
+            return Bitboard();
+        if (bits >= 64)
+            return Bitboard(0, b64[0] >> (bits - 64));
+        return Bitboard(b64[0] >> bits, (b64[0] << (64 - bits)) | (b64[1] >> bits));
+    }
+
+    constexpr Bitboard operator << (const int bits) const {
+        return *this << unsigned(bits);
+    }
+
+    constexpr Bitboard operator >> (const int bits) const {
+        return *this >> unsigned(bits);
+    }
+
+    constexpr bool operator == (const Bitboard y) const {
+        return (b64[0] == y.b64[0]) && (b64[1] == y.b64[1]);
+    }
+
+    constexpr bool operator != (const Bitboard y) const {
+        return !(*this == y);
+    }
+
+    inline Bitboard& operator |=(const Bitboard x) {
+        b64[0] |= x.b64[0];
+        b64[1] |= x.b64[1];
+        return *this;
+    }
+    inline Bitboard& operator &=(const Bitboard x) {
+        b64[0] &= x.b64[0];
+        b64[1] &= x.b64[1];
+        return *this;
+    }
+    inline Bitboard& operator ^=(const Bitboard x) {
+        b64[0] ^= x.b64[0];
+        b64[1] ^= x.b64[1];
+        return *this;
+    }
+
+    constexpr Bitboard operator ~ () const {
+        return Bitboard(~b64[0], ~b64[1]);
+    }
+
+    constexpr Bitboard operator - () const {
+        uint64_t n1 = 0ULL - b64[1];
+        uint64_t borrow = b64[1] != 0;
+        uint64_t n0 = 0ULL - b64[0] - borrow;
+        return Bitboard(n0, n1);
+    }
+
+    constexpr Bitboard operator | (const Bitboard x) const {
+        return Bitboard(b64[0] | x.b64[0], b64[1] | x.b64[1]);
+    }
+
+    constexpr Bitboard operator & (const Bitboard x) const {
+        return Bitboard(b64[0] & x.b64[0], b64[1] & x.b64[1]);
+    }
+
+    constexpr Bitboard operator ^ (const Bitboard x) const {
+        return Bitboard(b64[0] ^ x.b64[0], b64[1] ^ x.b64[1]);
+    }
+
+    constexpr Bitboard operator - (const Bitboard x) const {
+        uint64_t r1 = b64[1] - x.b64[1];
+        uint64_t borrow = b64[1] < x.b64[1];
+        uint64_t r0 = b64[0] - x.b64[0] - borrow;
+        return Bitboard(r0, r1);
+    }
+
+    constexpr Bitboard operator - (const int x) const {
+        return *this - Bitboard(x);
+    }
+
+    inline Bitboard operator * (const Bitboard x) const {
+#if defined(__GNUC__) || defined(__clang__)
+        unsigned __int128 lo = (unsigned __int128)b64[1] * x.b64[1];
+        unsigned __int128 cross1 = (unsigned __int128)b64[1] * x.b64[0];
+        unsigned __int128 cross2 = (unsigned __int128)b64[0] * x.b64[1];
+        uint64_t r1 = uint64_t(lo);
+        uint64_t r0 = uint64_t(lo >> 64);
+        r0 += uint64_t(cross1);
+        r0 += uint64_t(cross2);
+        return Bitboard(r0, r1);
+#else
+        Bitboard result;
+        for (int i = 0; i < 128; ++i)
+            if (((*this >> i) & Bitboard(1)))
+                result |= x << i;
+        return result;
+#endif
+    }
 };
 #endif
 constexpr int SQUARE_BITS = 7;
@@ -351,10 +468,17 @@ constexpr int MAX_PLY = 246;
 /// any normal move destination square is always different from origin square
 /// while MOVE_NONE and MOVE_NULL have the same origin and destination square.
 
+#if defined(VERY_LARGE_BOARDS)
+enum Move : uint64_t {
+  MOVE_NONE,
+  MOVE_NULL = 1 + (1ULL << SQUARE_BITS)
+};
+#else
 enum Move : int {
   MOVE_NONE,
   MOVE_NULL = 1 + (1 << SQUARE_BITS)
 };
+#endif
 
 enum MoveType : int {
   NORMAL,
@@ -942,7 +1066,8 @@ inline PieceType gating_type(Move m) {
 }
 
 inline Square gating_square(Move m) {
-  return Square((static_cast<uint32_t>(m) >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) & SQUARE_BIT_MASK);
+  const uint64_t raw = static_cast<uint64_t>(m);
+  return Square((raw >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) & SQUARE_BIT_MASK);
 }
 
 inline bool is_gating(Move m) {
@@ -954,16 +1079,22 @@ inline bool is_pass(Move m) {
 }
 
 constexpr Move make_move(Square from, Square to) {
-  return Move((from << SQUARE_BITS) + to);
+  return Move((static_cast<uint64_t>(from) << SQUARE_BITS) + static_cast<uint64_t>(to));
 }
 
 template<MoveType T>
 inline Move make(Square from, Square to, PieceType pt = NO_PIECE_TYPE) {
-  return Move((pt << (2 * SQUARE_BITS + MOVE_TYPE_BITS)) + T + (from << SQUARE_BITS) + to);
+  return Move((static_cast<uint64_t>(pt) << (2 * SQUARE_BITS + MOVE_TYPE_BITS))
+            + static_cast<uint64_t>(T)
+            + (static_cast<uint64_t>(from) << SQUARE_BITS)
+            + static_cast<uint64_t>(to));
 }
 
 constexpr Move make_drop(Square to, PieceType pt_in_hand, PieceType pt_dropped) {
-  return Move((pt_in_hand << (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) + (pt_dropped << (2 * SQUARE_BITS + MOVE_TYPE_BITS)) + DROP + to);
+  return Move((static_cast<uint64_t>(pt_in_hand) << (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS))
+            + (static_cast<uint64_t>(pt_dropped) << (2 * SQUARE_BITS + MOVE_TYPE_BITS))
+            + static_cast<uint64_t>(DROP)
+            + static_cast<uint64_t>(to));
 }
 
 constexpr Move reverse_move(Move m) {
@@ -972,7 +1103,11 @@ constexpr Move reverse_move(Move m) {
 
 template<MoveType T>
 constexpr Move make_gating(Square from, Square to, PieceType pt, Square gate) {
-  return Move((gate << (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) + (pt << (2 * SQUARE_BITS + MOVE_TYPE_BITS)) + T + (from << SQUARE_BITS) + to);
+  return Move((static_cast<uint64_t>(gate) << (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS))
+            + (static_cast<uint64_t>(pt) << (2 * SQUARE_BITS + MOVE_TYPE_BITS))
+            + static_cast<uint64_t>(T)
+            + (static_cast<uint64_t>(from) << SQUARE_BITS)
+            + static_cast<uint64_t>(to));
 }
 
 constexpr PieceType dropped_piece_type(Move m) {

--- a/src/types.h
+++ b/src/types.h
@@ -78,7 +78,7 @@
 #  include <xmmintrin.h> // Intel and Microsoft header for _mm_prefetch()
 #endif
 
-#if defined(USE_PEXT)
+#if defined(USE_PEXT) && !defined(VERY_LARGE_BOARDS)
 #  include <immintrin.h> // Header for _pext_u64() intrinsic
 #  ifdef LARGEBOARDS
 #    define pext(b, m) (_pext_u64(b, m) ^ (_pext_u64(b >> 64, m >> 64) << popcount((m << 64) >> 64)))
@@ -97,7 +97,7 @@ constexpr bool HasPopCnt = true;
 constexpr bool HasPopCnt = false;
 #endif
 
-#ifdef USE_PEXT
+#if defined(USE_PEXT) && !defined(VERY_LARGE_BOARDS)
 constexpr bool HasPext = true;
 #else
 constexpr bool HasPext = false;
@@ -110,41 +110,89 @@ constexpr bool Is64Bit = false;
 #endif
 
 typedef uint64_t Key;
-#ifdef LARGEBOARDS
-#if defined(__GNUC__) && defined(IS_64BIT)
-typedef unsigned __int128 Bitboard;
-#else
-struct Bitboard {
-    uint64_t b64[2];
 
-    constexpr Bitboard() : b64 {0, 0} {}
-    constexpr Bitboard(uint64_t i) : b64 {0, i} {}
-    constexpr Bitboard(uint64_t hi, uint64_t lo) : b64 {hi, lo} {};
+#if defined(VERY_LARGE_BOARDS) && !defined(LARGEBOARDS)
+#  define LARGEBOARDS
+#endif
+
+#ifdef VERY_LARGE_BOARDS
+struct Bitboard {
+    uint64_t b64[4];
+
+    constexpr Bitboard() : b64 {0, 0, 0, 0} {}
+    constexpr Bitboard(uint64_t i) : b64 {0, 0, 0, i} {}
+    constexpr Bitboard(uint64_t b3, uint64_t b2, uint64_t b1, uint64_t b0) : b64 {b3, b2, b1, b0} {}
 
     constexpr operator bool() const {
-        return b64[0] || b64[1];
+        return b64[0] || b64[1] || b64[2] || b64[3];
     }
 
     constexpr operator long long unsigned () const {
-        return b64[1];
+        return b64[3];
     }
 
     constexpr operator unsigned() const {
-        return b64[1];
+        return b64[3];
     }
 
     constexpr Bitboard operator << (const unsigned int bits) const {
-        return Bitboard(  bits >= 64 ? b64[1] << (bits - 64)
-                        : bits == 0  ? b64[0]
-                        : ((b64[0] << bits) | (b64[1] >> (64 - bits))),
-                        bits >= 64 ? 0 : b64[1] << bits);
+        if (bits == 0)
+            return *this;
+        if (bits >= 256)
+            return Bitboard();
+        if (bits >= 192)
+            return Bitboard(b64[3] << (bits - 192), 0, 0, 0);
+        if (bits >= 128)
+        {
+            const unsigned shift = bits - 128;
+            return Bitboard(  (b64[2] << shift) | (shift ? (b64[3] >> (64 - shift)) : 0),
+                              b64[3] << shift,
+                              0, 0);
+        }
+        if (bits >= 64)
+        {
+            const unsigned shift = bits - 64;
+            return Bitboard(  (b64[1] << shift) | (shift ? (b64[2] >> (64 - shift)) : 0),
+                              (b64[2] << shift) | (shift ? (b64[3] >> (64 - shift)) : 0),
+                              b64[3] << shift,
+                              0);
+        }
+        return Bitboard(  (b64[0] << bits) | (b64[1] >> (64 - bits)),
+                          (b64[1] << bits) | (b64[2] >> (64 - bits)),
+                          (b64[2] << bits) | (b64[3] >> (64 - bits)),
+                          b64[3] << bits);
     }
 
     constexpr Bitboard operator >> (const unsigned int bits) const {
-        return Bitboard(bits >= 64 ? 0 : b64[0] >> bits,
-                          bits >= 64 ? b64[0] >> (bits - 64)
-                        : bits == 0  ? b64[1]
-                        : ((b64[1] >> bits) | (b64[0] << (64 - bits))));
+        if (bits == 0)
+            return *this;
+        if (bits >= 256)
+            return Bitboard();
+        if (bits >= 192)
+            return Bitboard(0, 0, 0, b64[0] >> (bits - 192));
+        if (bits >= 128)
+        {
+            const unsigned shift = bits - 128;
+            if (shift == 0)
+                return Bitboard(0, 0, b64[0], b64[1]);
+            return Bitboard(0, 0,
+                            b64[0] >> shift,
+                            (b64[0] << (64 - shift)) | (b64[1] >> shift));
+        }
+        if (bits >= 64)
+        {
+            const unsigned shift = bits - 64;
+            if (shift == 0)
+                return Bitboard(0, b64[0], b64[1], b64[2]);
+            return Bitboard(0,
+                            b64[0] >> shift,
+                            (b64[0] << (64 - shift)) | (b64[1] >> shift),
+                            (b64[1] << (64 - shift)) | (b64[2] >> shift));
+        }
+        return Bitboard(  b64[0] >> bits,
+                          (b64[0] << (64 - bits)) | (b64[1] >> bits),
+                          (b64[1] << (64 - bits)) | (b64[2] >> bits),
+                          (b64[2] << (64 - bits)) | (b64[3] >> bits));
     }
 
     constexpr Bitboard operator << (const int bits) const {
@@ -166,41 +214,61 @@ struct Bitboard {
     inline Bitboard& operator |=(const Bitboard x) {
         b64[0] |= x.b64[0];
         b64[1] |= x.b64[1];
+        b64[2] |= x.b64[2];
+        b64[3] |= x.b64[3];
         return *this;
     }
     inline Bitboard& operator &=(const Bitboard x) {
         b64[0] &= x.b64[0];
         b64[1] &= x.b64[1];
+        b64[2] &= x.b64[2];
+        b64[3] &= x.b64[3];
         return *this;
     }
     inline Bitboard& operator ^=(const Bitboard x) {
         b64[0] ^= x.b64[0];
         b64[1] ^= x.b64[1];
+        b64[2] ^= x.b64[2];
+        b64[3] ^= x.b64[3];
         return *this;
     }
 
     constexpr Bitboard operator ~ () const {
-        return Bitboard(~b64[0], ~b64[1]);
+        return Bitboard(~b64[0], ~b64[1], ~b64[2], ~b64[3]);
     }
 
     constexpr Bitboard operator - () const {
-        return Bitboard(-b64[0] - (b64[1] > 0), -b64[1]);
+        uint64_t n3 = 0ULL - b64[3];
+        uint64_t borrow = b64[3] != 0;
+        uint64_t n2 = 0ULL - b64[2] - borrow;
+        borrow = (b64[2] != 0) || borrow;
+        uint64_t n1 = 0ULL - b64[1] - borrow;
+        borrow = (b64[1] != 0) || borrow;
+        uint64_t n0 = 0ULL - b64[0] - borrow;
+        return Bitboard(n0, n1, n2, n3);
     }
 
     constexpr Bitboard operator | (const Bitboard x) const {
-        return Bitboard(b64[0] | x.b64[0], b64[1] | x.b64[1]);
+        return Bitboard(b64[0] | x.b64[0], b64[1] | x.b64[1], b64[2] | x.b64[2], b64[3] | x.b64[3]);
     }
 
     constexpr Bitboard operator & (const Bitboard x) const {
-        return Bitboard(b64[0] & x.b64[0], b64[1] & x.b64[1]);
+        return Bitboard(b64[0] & x.b64[0], b64[1] & x.b64[1], b64[2] & x.b64[2], b64[3] & x.b64[3]);
     }
 
     constexpr Bitboard operator ^ (const Bitboard x) const {
-        return Bitboard(b64[0] ^ x.b64[0], b64[1] ^ x.b64[1]);
+        return Bitboard(b64[0] ^ x.b64[0], b64[1] ^ x.b64[1], b64[2] ^ x.b64[2], b64[3] ^ x.b64[3]);
     }
 
     constexpr Bitboard operator - (const Bitboard x) const {
-        return Bitboard(b64[0] - x.b64[0] - (b64[1] < x.b64[1]), b64[1] - x.b64[1]);
+        uint64_t r3 = b64[3] - x.b64[3];
+        uint64_t borrow = b64[3] < x.b64[3];
+        uint64_t r2 = b64[2] - x.b64[2] - borrow;
+        borrow = (b64[2] < x.b64[2]) || (borrow && b64[2] == x.b64[2]);
+        uint64_t r1 = b64[1] - x.b64[1] - borrow;
+        borrow = (b64[1] < x.b64[1]) || (borrow && b64[1] == x.b64[1]);
+        uint64_t r0 = b64[0] - x.b64[0] - borrow;
+        return Bitboard(r0, r1, r2, r3);
     }
 
     constexpr Bitboard operator - (const int x) const {
@@ -208,17 +276,44 @@ struct Bitboard {
     }
 
     inline Bitboard operator * (const Bitboard x) const {
-        uint64_t a_lo = (uint32_t)b64[1];
-        uint64_t a_hi = b64[1] >> 32;
-        uint64_t b_lo = (uint32_t)x.b64[1];
-        uint64_t b_hi = x.b64[1] >> 32;
+#if defined(__GNUC__) || defined(__clang__)
+        uint64_t r[4] = {0, 0, 0, 0};
+        const uint64_t a[4] = { b64[3], b64[2], b64[1], b64[0] };
+        const uint64_t b[4] = { x.b64[3], x.b64[2], x.b64[1], x.b64[0] };
 
-        uint64_t t1 = (a_hi * b_lo) + ((a_lo * b_lo) >> 32);
-        uint64_t t2 = (a_lo * b_hi) + (t1 & 0xFFFFFFFF);
-
-        return Bitboard(b64[0] * x.b64[1] + b64[1] * x.b64[0] + (a_hi * b_hi) + (t1 >> 32) + (t2 >> 32),
-                        (t2 << 32) + (a_lo * b_lo & 0xFFFFFFFF));
+        for (int i = 0; i < 4; ++i)
+        {
+            unsigned __int128 carry = 0;
+            for (int j = 0; j + i < 4; ++j)
+            {
+                unsigned __int128 t = (unsigned __int128)a[i] * b[j];
+                t += r[i + j];
+                t += carry;
+                r[i + j] = uint64_t(t);
+                carry = t >> 64;
+            }
+        }
+        return Bitboard(r[3], r[2], r[1], r[0]);
+#else
+        Bitboard result;
+        for (int i = 0; i < 256; ++i)
+            if (((*this >> i) & Bitboard(1)))
+                result |= x << i;
+        return result;
+#endif
    }
+};
+constexpr int SQUARE_BITS = 8;
+#elif defined(LARGEBOARDS)
+#if defined(__GNUC__) && defined(IS_64BIT)
+typedef unsigned __int128 Bitboard;
+#else
+struct Bitboard {
+    uint64_t b64[2];
+
+    constexpr Bitboard() : b64 {0, 0} {}
+    constexpr Bitboard(uint64_t i) : b64 {0, i} {}
+    constexpr Bitboard(uint64_t hi, uint64_t lo) : b64 {hi, lo} {};
 };
 #endif
 constexpr int SQUARE_BITS = 7;
@@ -494,7 +589,24 @@ enum : int {
 };
 
 enum Square : int {
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1, SQ_I1, SQ_J1, SQ_K1, SQ_L1, SQ_M1, SQ_N1, SQ_O1, SQ_P1,
+  SQ_A2, SQ_B2, SQ_C2, SQ_D2, SQ_E2, SQ_F2, SQ_G2, SQ_H2, SQ_I2, SQ_J2, SQ_K2, SQ_L2, SQ_M2, SQ_N2, SQ_O2, SQ_P2,
+  SQ_A3, SQ_B3, SQ_C3, SQ_D3, SQ_E3, SQ_F3, SQ_G3, SQ_H3, SQ_I3, SQ_J3, SQ_K3, SQ_L3, SQ_M3, SQ_N3, SQ_O3, SQ_P3,
+  SQ_A4, SQ_B4, SQ_C4, SQ_D4, SQ_E4, SQ_F4, SQ_G4, SQ_H4, SQ_I4, SQ_J4, SQ_K4, SQ_L4, SQ_M4, SQ_N4, SQ_O4, SQ_P4,
+  SQ_A5, SQ_B5, SQ_C5, SQ_D5, SQ_E5, SQ_F5, SQ_G5, SQ_H5, SQ_I5, SQ_J5, SQ_K5, SQ_L5, SQ_M5, SQ_N5, SQ_O5, SQ_P5,
+  SQ_A6, SQ_B6, SQ_C6, SQ_D6, SQ_E6, SQ_F6, SQ_G6, SQ_H6, SQ_I6, SQ_J6, SQ_K6, SQ_L6, SQ_M6, SQ_N6, SQ_O6, SQ_P6,
+  SQ_A7, SQ_B7, SQ_C7, SQ_D7, SQ_E7, SQ_F7, SQ_G7, SQ_H7, SQ_I7, SQ_J7, SQ_K7, SQ_L7, SQ_M7, SQ_N7, SQ_O7, SQ_P7,
+  SQ_A8, SQ_B8, SQ_C8, SQ_D8, SQ_E8, SQ_F8, SQ_G8, SQ_H8, SQ_I8, SQ_J8, SQ_K8, SQ_L8, SQ_M8, SQ_N8, SQ_O8, SQ_P8,
+  SQ_A9, SQ_B9, SQ_C9, SQ_D9, SQ_E9, SQ_F9, SQ_G9, SQ_H9, SQ_I9, SQ_J9, SQ_K9, SQ_L9, SQ_M9, SQ_N9, SQ_O9, SQ_P9,
+  SQ_A10, SQ_B10, SQ_C10, SQ_D10, SQ_E10, SQ_F10, SQ_G10, SQ_H10, SQ_I10, SQ_J10, SQ_K10, SQ_L10, SQ_M10, SQ_N10, SQ_O10, SQ_P10,
+  SQ_A11, SQ_B11, SQ_C11, SQ_D11, SQ_E11, SQ_F11, SQ_G11, SQ_H11, SQ_I11, SQ_J11, SQ_K11, SQ_L11, SQ_M11, SQ_N11, SQ_O11, SQ_P11,
+  SQ_A12, SQ_B12, SQ_C12, SQ_D12, SQ_E12, SQ_F12, SQ_G12, SQ_H12, SQ_I12, SQ_J12, SQ_K12, SQ_L12, SQ_M12, SQ_N12, SQ_O12, SQ_P12,
+  SQ_A13, SQ_B13, SQ_C13, SQ_D13, SQ_E13, SQ_F13, SQ_G13, SQ_H13, SQ_I13, SQ_J13, SQ_K13, SQ_L13, SQ_M13, SQ_N13, SQ_O13, SQ_P13,
+  SQ_A14, SQ_B14, SQ_C14, SQ_D14, SQ_E14, SQ_F14, SQ_G14, SQ_H14, SQ_I14, SQ_J14, SQ_K14, SQ_L14, SQ_M14, SQ_N14, SQ_O14, SQ_P14,
+  SQ_A15, SQ_B15, SQ_C15, SQ_D15, SQ_E15, SQ_F15, SQ_G15, SQ_H15, SQ_I15, SQ_J15, SQ_K15, SQ_L15, SQ_M15, SQ_N15, SQ_O15, SQ_P15,
+  SQ_A16, SQ_B16, SQ_C16, SQ_D16, SQ_E16, SQ_F16, SQ_G16, SQ_H16, SQ_I16, SQ_J16, SQ_K16, SQ_L16, SQ_M16, SQ_N16, SQ_O16, SQ_P16,
+#elif defined(LARGEBOARDS)
   SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1, SQ_I1, SQ_J1, SQ_K1, SQ_L1,
   SQ_A2, SQ_B2, SQ_C2, SQ_D2, SQ_E2, SQ_F2, SQ_G2, SQ_H2, SQ_I2, SQ_J2, SQ_K2, SQ_L2,
   SQ_A3, SQ_B3, SQ_C3, SQ_D3, SQ_E3, SQ_F3, SQ_G3, SQ_H3, SQ_I3, SQ_J3, SQ_K3, SQ_L3,
@@ -518,7 +630,10 @@ enum Square : int {
   SQ_NONE,
 
   SQUARE_ZERO = 0,
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  SQUARE_NB = 256,
+  SQUARE_BIT_MASK = 255,
+#elif defined(LARGEBOARDS)
   SQUARE_NB = 120,
   SQUARE_BIT_MASK = 127,
 #else
@@ -531,7 +646,9 @@ enum Square : int {
 };
 
 enum Direction : int {
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  NORTH =  16,
+#elif defined(LARGEBOARDS)
   NORTH =  12,
 #else
   NORTH =  8,
@@ -547,7 +664,10 @@ enum Direction : int {
 };
 
 enum File : int {
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H,
+  FILE_I, FILE_J, FILE_K, FILE_L, FILE_M, FILE_N, FILE_O, FILE_P,
+#elif defined(LARGEBOARDS)
   FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE_I, FILE_J, FILE_K, FILE_L,
 #else
   FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H,
@@ -557,7 +677,10 @@ enum File : int {
 };
 
 enum Rank : int {
-#ifdef LARGEBOARDS
+#if defined(VERY_LARGE_BOARDS)
+  RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8,
+  RANK_9, RANK_10, RANK_11, RANK_12, RANK_13, RANK_14, RANK_15, RANK_16,
+#elif defined(LARGEBOARDS)
   RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9, RANK_10,
 #else
   RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8,
@@ -819,7 +942,7 @@ inline PieceType gating_type(Move m) {
 }
 
 inline Square gating_square(Move m) {
-  return Square((m >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) & SQUARE_BIT_MASK);
+  return Square((static_cast<uint32_t>(m) >> (2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS)) & SQUARE_BIT_MASK);
 }
 
 inline bool is_gating(Move m) {

--- a/src/types.h
+++ b/src/types.h
@@ -414,7 +414,7 @@ struct Bitboard {
     }
 
     inline Bitboard operator * (const Bitboard x) const {
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && defined(__SIZEOF_INT128__)
         unsigned __int128 lo = (unsigned __int128)b64[1] * x.b64[1];
         unsigned __int128 cross1 = (unsigned __int128)b64[1] * x.b64[0];
         unsigned __int128 cross2 = (unsigned __int128)b64[0] * x.b64[1];

--- a/src/types.h
+++ b/src/types.h
@@ -414,22 +414,16 @@ struct Bitboard {
     }
 
     inline Bitboard operator * (const Bitboard x) const {
-#if (defined(__GNUC__) || defined(__clang__)) && defined(__SIZEOF_INT128__)
-        unsigned __int128 lo = (unsigned __int128)b64[1] * x.b64[1];
-        unsigned __int128 cross1 = (unsigned __int128)b64[1] * x.b64[0];
-        unsigned __int128 cross2 = (unsigned __int128)b64[0] * x.b64[1];
-        uint64_t r1 = uint64_t(lo);
-        uint64_t r0 = uint64_t(lo >> 64);
-        r0 += uint64_t(cross1);
-        r0 += uint64_t(cross2);
-        return Bitboard(r0, r1);
-#else
-        Bitboard result;
-        for (int i = 0; i < 128; ++i)
-            if (((*this >> i) & Bitboard(1)))
-                result |= x << i;
-        return result;
-#endif
+        uint64_t a_lo = (uint32_t)b64[1];
+        uint64_t a_hi = b64[1] >> 32;
+        uint64_t b_lo = (uint32_t)x.b64[1];
+        uint64_t b_hi = x.b64[1] >> 32;
+
+        uint64_t t1 = (a_hi * b_lo) + ((a_lo * b_lo) >> 32);
+        uint64_t t2 = (a_lo * b_hi) + (t1 & 0xFFFFFFFF);
+
+        return Bitboard(b64[0] * x.b64[1] + b64[1] * x.b64[0] + (a_hi * b_hi) + (t1 >> 32) + (t2 >> 32),
+                        (t2 << 32) + (a_lo * b_lo & 0xFFFFFFFF));
     }
 };
 #endif

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -16,8 +16,11 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <cassert>
+#include <bitset>
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -391,13 +394,35 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     const Variant* v = variants.find(variant)->second;
     std::cerr << "Writing config for variant " + variant << std::endl;
 
-    const int dataSize = (v->maxFile + 1) * (v->maxRank + 1) + v->nnueMaxPieces * 5
-                        + popcount(v->pieceTypes) * 2 * 5 + 50 > 512 ? 1024 : 512;
+    auto bits_needed = [](int value) {
+        int bits = 0;
+        unsigned int v = value <= 0 ? 0u : static_cast<unsigned int>(value);
+        while ((1u << bits) <= v && bits < 31)
+            ++bits;
+        return bits ? bits : 1;
+    };
+
+    const int squares = (v->maxFile + 1) * (v->maxRank + 1);
+    const int pieceTypes = static_cast<int>(std::bitset<64>(v->pieceTypes).count());
+    const bool useWide = squares > 128 || pieceTypes > 16;
+    const int squareBits = bits_needed(squares - 1);
+    const int kingBits = useWide ? squareBits : 7;
+    const int epBits = useWide ? squareBits : 7;
+    const int pieceBits = bits_needed(2 * pieceTypes);
+    const int pocketBits = useWide ? bits_needed(v->nnueMaxPieces) : (DATA_SIZE > 512 ? 7 : 5);
+    const int boardSquares = squares - (v->nnueKing != NO_PIECE_TYPE ? 2 : 0);
+    const int boardBits = useWide ? boardSquares * pieceBits : boardSquares * 6;
+    const int dataBits = 1 + 2 * kingBits + boardBits + 2 * pieceTypes * pocketBits
+                       + 4 + 1 + epBits + 6 + 8 + 8 + 1;
+
+    int dataSize = 512;
+    while (dataSize < dataBits)
+        dataSize *= 2;
 
     if (dataSize > DATA_SIZE)
         std::cerr << std::endl << "Warning: Recommended training data size " << dataSize
                   << " not compatible with current version. "
-                  << "Please recompile with largedata=yes" << std::endl << std::endl;
+                  << "Please recompile with datasize=" << dataSize << " (or adjust largedata/verylargeboards)" << std::endl << std::endl;
 
     if (out1.is_open())
         std::cerr << "Writing variant.h to " << path << std::endl;
@@ -410,6 +435,8 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     << "#define PIECE_COUNT " << v->nnueMaxPieces << std::endl
     << "#define POCKETS " << (v->nnueUsePockets ? "true" : "false") << std::endl
     << "#define KING_SQUARES " << v->nnueKingSquare << std::endl
+    << "#define NNUE_KING " << (v->nnueKing != NO_PIECE_TYPE ? 1 : 0) << std::endl
+    << "#define MOVE_SQUARE_BITS " << SQUARE_BITS << std::endl
     << "#define DATA_SIZE " << DATA_SIZE << std::endl;
 
     if (out1.is_open()) {
@@ -425,8 +452,10 @@ void search_mcts_cmd(Position& pos, istringstream& is)
     << "FILES = " << v->maxFile + 1 << std::endl
     << "SQUARES = RANKS * FILES" << std::endl
     << "KING_SQUARES = " << v->nnueKingSquare << std::endl
+    << "NNUE_KING = " << (v->nnueKing != NO_PIECE_TYPE ? "True" : "False") << std::endl
     << "PIECE_TYPES = " << popcount(v->pieceTypes) << std::endl
     << "PIECES = 2 * PIECE_TYPES" << std::endl
+    << "MOVE_SQUARE_BITS = " << SQUARE_BITS << std::endl
     << "USE_POCKETS = " << (v->nnueUsePockets ? "True" : "False") << std::endl
     << "POCKETS = 2 * FILES if USE_POCKETS else 0" << std::endl
     << std::endl
@@ -677,9 +706,9 @@ string UCI::dropped_piece(const Position& pos, Move m) {
   assert(type_of(m) == DROP);
   if (dropped_piece_type(m) == pos.promoted_piece_type(in_hand_piece_type(m)))
       // Dropping as promoted piece
-      return std::string{'+', pos.piece_to_char()[in_hand_piece_type(m)]};
+      return std::string("+") + pos.piece_symbol(make_piece(WHITE, in_hand_piece_type(m)));
   else
-      return std::string{pos.piece_to_char()[dropped_piece_type(m)]};
+      return pos.piece_symbol(make_piece(WHITE, dropped_piece_type(m)));
 }
 
 
@@ -692,6 +721,7 @@ string UCI::move(const Position& pos, Move m) {
 
   Square from = from_sq(m);
   Square to = to_sq(m);
+  Square gate = pos.gate_square(m);
 
   if (m == MOVE_NONE)
       return CurrentProtocol == USI ? "resign" : "(none)";
@@ -702,7 +732,7 @@ string UCI::move(const Position& pos, Move m) {
   if (is_pass(m) && CurrentProtocol == XBOARD)
       return "@@@@";
 
-  if (is_gating(m) && gating_square(m) == to)
+  if (is_gating(m) && gate == to)
       from = to_sq(m), to = from_sq(m);
   else if (type_of(m) == CASTLING && !pos.is_chess960())
   {
@@ -717,24 +747,24 @@ string UCI::move(const Position& pos, Move m) {
 
   // Wall square
   if (pos.walling() && CurrentProtocol == XBOARD)
-      move += "," + UCI::square(pos, to) + UCI::square(pos, gating_square(m));
+      move += "," + UCI::square(pos, to) + UCI::square(pos, gate);
 
   if (type_of(m) == PROMOTION)
-      move += pos.piece_to_char()[make_piece(BLACK, promotion_type(m))];
+      move += pos.piece_symbol(make_piece(BLACK, promotion_type(m)));
   else if (type_of(m) == PIECE_PROMOTION)
       move += '+';
   else if (type_of(m) == PIECE_DEMOTION)
       move += '-';
   else if (is_gating(m))
   {
-      move += pos.piece_to_char()[make_piece(BLACK, gating_type(m))];
-      if (gating_square(m) != from)
-          move += UCI::square(pos, gating_square(m));
+      move += pos.piece_symbol(make_piece(BLACK, gating_type(m)));
+      if (gate != from)
+          move += UCI::square(pos, gate);
   }
 
   // Wall square
   if (pos.walling() && CurrentProtocol != XBOARD)
-      move += "," + UCI::square(pos, to) + UCI::square(pos, gating_square(m));
+      move += "," + UCI::square(pos, to) + UCI::square(pos, gate);
 
   return move;
 }
@@ -745,14 +775,23 @@ string UCI::move(const Position& pos, Move m) {
 
 Move UCI::to_move(const Position& pos, string& str) {
 
-  if (str.length() == 5)
+  if (!str.empty())
   {
-      if (str[4] == '=')
-          // shogi moves refraining from promotion might use equals sign
-          str.pop_back();
-      else
-          // Junior could send promotion piece in uppercase
-          str[4] = char(tolower(str[4]));
+      // shogi moves refraining from promotion might use equals sign
+      str.erase(std::remove(str.begin(), str.end(), '='), str.end());
+
+      // Junior could send promotion piece in uppercase
+      if (str.size() >= 5)
+      {
+          size_t last = str.size() - 1;
+          if (Variant::is_piece_id_suffix(str[last]))
+          {
+              if (last >= 1 && std::isalpha(static_cast<unsigned char>(str[last - 1])))
+                  str[last - 1] = char(std::tolower(static_cast<unsigned char>(str[last - 1])));
+          }
+          else if (std::isalpha(static_cast<unsigned char>(str[last])))
+              str[last] = char(std::tolower(static_cast<unsigned char>(str[last])));
+      }
   }
 
   for (const auto& m : MoveList<LEGAL>(pos))

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -157,10 +157,10 @@ void on_variant_change(const Option &o) {
                     suffix += "s";
                 suffix += "@" + std::to_string(pt == PAWN && !v->promotionZonePawnDrops && v->promotionRegion[WHITE] ? rank_of(lsb(v->promotionRegion[WHITE])) : v->maxRank + 1);
             }
-            sync_cout << "piece " << v->pieceToChar[pt] << "& " << pieceMap.find(pt == KING ? v->kingType : pt)->second->betza << suffix << sync_endl;
+            sync_cout << "piece " << v->piece_symbol(make_piece(WHITE, pt)) << "& " << pieceMap.find(pt == KING ? v->kingType : pt)->second->betza << suffix << sync_endl;
             PieceType promType = v->promotedPieceType[pt];
             if (promType)
-                sync_cout << "piece +" << v->pieceToChar[pt] << "& " << pieceMap.find(promType)->second->betza << sync_endl;
+                sync_cout << "piece +" << v->piece_symbol(make_piece(WHITE, pt)) << "& " << pieceMap.find(promType)->second->betza << sync_endl;
         }
     }
     else

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -32,6 +32,65 @@ namespace Stockfish {
 VariantMap variants; // Global object
 
 namespace {
+    int count_piece_symbol_in_fen(const std::string& fenBoard, const std::string& symbol) {
+        if (symbol.empty())
+            return 0;
+
+        int count = 0;
+        for (size_t i = 0; i < fenBoard.size(); ++i)
+        {
+            char c = fenBoard[i];
+            if (std::isspace(static_cast<unsigned char>(c)))
+                break;
+            if (c == '+')
+            {
+                if (++i >= fenBoard.size())
+                    break;
+                c = fenBoard[i];
+            }
+            if (Variant::is_piece_id_start(c))
+            {
+                std::string token(1, c);
+                if (i + 1 < fenBoard.size() && Variant::is_piece_id_suffix(fenBoard[i + 1]))
+                {
+                    token.push_back(fenBoard[i + 1]);
+                    ++i;
+                }
+                if (token == symbol)
+                    ++count;
+            }
+        }
+        return count;
+    }
+
+    int count_all_pieces_in_fen(const std::string& fenBoard, const Variant* v) {
+        int count = 0;
+        for (size_t i = 0; i < fenBoard.size(); ++i)
+        {
+            char c = fenBoard[i];
+            if (std::isspace(static_cast<unsigned char>(c)))
+                break;
+            if (c == '+')
+            {
+                if (++i >= fenBoard.size())
+                    break;
+                c = fenBoard[i];
+            }
+            if (Variant::is_piece_id_start(c))
+            {
+                std::string token(1, c);
+                if (i + 1 < fenBoard.size() && Variant::is_piece_id_suffix(fenBoard[i + 1]))
+                {
+                    token.push_back(fenBoard[i + 1]);
+                    ++i;
+                }
+                if (v->piece_type_from_symbol(token) != NO_PIECE_TYPE)
+                    ++count;
+            }
+        }
+        return count;
+    }
+
     // Base variant
     Variant* variant_base() {
         Variant* v = new Variant();
@@ -1604,6 +1663,30 @@ namespace {
         v->doubleStepRegion[BLACK] = Rank8BB;
         return v;
     }
+#ifdef VERY_LARGE_BOARDS
+    // Omega chess
+    Variant* omega_variant() {
+        Variant* v = chess_variant_base()->init();
+        v->pieceToCharTable = "PNBRQ..C.W...........Kpnbrq..c.w...........k";
+        v->maxRank = RANK_12;
+        v->maxFile = FILE_L;
+        v->startFen = "w**********w/*crnbqkbnrc*/*pppppppppp*/*10*/*10*/*10*/*10*/*10*/*10*/*PPPPPPPPPP*/*CRNBQKBNRC*/W**********W w KQkq - 0 1";
+        v->add_piece(CUSTOM_PIECE_1, 'c', "DAW"); // Champion
+        v->add_piece(CUSTOM_PIECE_2, 'w', "CF");  // Wizard
+        v->promotionRegion[WHITE] = Rank9BB | Rank10BB;
+        v->promotionRegion[BLACK] = Rank2BB | Rank1BB;
+        v->promotionPieceTypes[WHITE] = piece_set(CUSTOM_PIECE_2) | CUSTOM_PIECE_1 | QUEEN | ROOK | BISHOP | KNIGHT;
+        v->promotionPieceTypes[BLACK] = v->promotionPieceTypes[WHITE];
+        v->doubleStepRegion[WHITE] = Rank3BB;
+        v->doubleStepRegion[BLACK] = Rank8BB;
+        v->tripleStepRegion[WHITE] = Rank3BB;
+        v->tripleStepRegion[BLACK] = Rank8BB;
+        v->castlingKingsideFile = FILE_I;
+        v->castlingQueensideFile = FILE_E;
+        v->castlingRank = RANK_2;
+        return v;
+    }
+#endif
     // Troitzky Chess
     // https://www.chessvariants.com/play/troitzky-chess
     Variant* troitzky_variant() {
@@ -1937,6 +2020,9 @@ void VariantMap::init() {
     add("opulent", opulent_variant());
     add("tencubed", tencubed_variant());
     add("omicron", omicron_variant());
+#ifdef VERY_LARGE_BOARDS
+    add("omega", omega_variant());
+#endif
     add("troitzky", troitzky_variant());
     add("wolf", wolf_variant());
     add("shako", shako_variant());
@@ -1958,6 +2044,7 @@ void VariantMap::init() {
 
 // Pre-calculate derived properties
 Variant* Variant::conclude() {
+    rebuild_piece_symbol_maps();
     // Enforce consistency to allow runtime optimizations
     if (!doubleStep)
         doubleStepRegion[WHITE] = doubleStepRegion[BLACK] = 0;
@@ -2000,8 +2087,8 @@ Variant* Variant::conclude() {
     {
         std::string fenBoard = startFen.substr(0, startFen.find(' '));
         // Switch NNUE from KA to A if there is no unique piece
-        if (   std::count(fenBoard.begin(), fenBoard.end(), pieceToChar[make_piece(WHITE, nnueKing)]) != 1
-            || std::count(fenBoard.begin(), fenBoard.end(), pieceToChar[make_piece(BLACK, nnueKing)]) != 1)
+        if (   count_piece_symbol_in_fen(fenBoard, piece_symbol(make_piece(WHITE, nnueKing))) != 1
+            || count_piece_symbol_in_fen(fenBoard, piece_symbol(make_piece(BLACK, nnueKing))) != 1)
             nnueKing = NO_PIECE_TYPE;
     }
     // We can not use popcount here yet, as the lookup tables are initialized after the variants
@@ -2051,15 +2138,8 @@ Variant* Variant::conclude() {
     nnueDimensions = nnueKingSquare * nnuePieceIndices;
 
     // Determine maximum piece count
-    std::istringstream ss(startFen);
-    ss >> std::noskipws;
-    unsigned char token;
-    nnueMaxPieces = 0;
-    while ((ss >> token) && !isspace(token))
-    {
-        if (pieceToChar.find(token) != std::string::npos || pieceToCharSynonyms.find(token) != std::string::npos)
-            nnueMaxPieces++;
-    }
+    std::string fenBoard = startFen.substr(0, startFen.find(' '));
+    nnueMaxPieces = count_all_pieces_in_fen(fenBoard, this);
     if (twoBoards)
         nnueMaxPieces *= 2;
 

--- a/src/variant.h
+++ b/src/variant.h
@@ -27,6 +27,7 @@
 #include <functional>
 #include <sstream>
 #include <iostream>
+#include <cctype>
 
 #include "types.h"
 #include "bitboard.h"
@@ -49,6 +50,10 @@ struct Variant {
   std::string pieceToChar =  " PNBRQ" + std::string(KING - QUEEN - 1, ' ') + "K" + std::string(PIECE_TYPE_NB - KING - 1, ' ')
                            + " pnbrq" + std::string(KING - QUEEN - 1, ' ') + "k" + std::string(PIECE_TYPE_NB - KING - 1, ' ');
   std::string pieceToCharSynonyms = std::string(PIECE_NB, ' ');
+  std::vector<std::string> pieceToSymbol = std::vector<std::string>(PIECE_NB, "");
+  std::vector<std::string> pieceToSymbolSynonyms = std::vector<std::string>(PIECE_NB, "");
+  std::map<std::string, Piece> symbolToPiece;
+  std::map<std::string, PieceType> symbolToPieceType;
   std::string startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
   Bitboard mobilityRegion[COLOR_NB][PIECE_TYPE_NB] = {};
   Bitboard promotionRegion[COLOR_NB] = {Rank8BB, Rank1BB};
@@ -180,20 +185,122 @@ struct Variant {
   bool shogiStylePromotions = false;
   std::vector<Direction> connectDirections;
   PieceSet connectPieceTypesTrimmed = ~NO_PIECE_SET;
-  void add_piece(PieceType pt, char c, std::string betza = "", char c2 = ' ') {
-      // Avoid ambiguous definition by removing existing piece with same letter
-      size_t idx;
-      if ((idx = pieceToChar.find(toupper(c))) != std::string::npos)
-          remove_piece(PieceType(idx));
-      // Now add new piece
-      pieceToChar[make_piece(WHITE, pt)] = toupper(c);
-      pieceToChar[make_piece(BLACK, pt)] = tolower(c);
-      pieceToCharSynonyms[make_piece(WHITE, pt)] = toupper(c2);
-      pieceToCharSynonyms[make_piece(BLACK, pt)] = tolower(c2);
+  static bool is_piece_id_suffix(char c) {
+      return c == '\'' || c == '"' || c == '!';
+  }
+
+  static bool is_piece_id_start(char c) {
+      return std::isalpha(static_cast<unsigned char>(c));
+  }
+
+  static std::string normalize_piece_symbol(const std::string& token, Color c) {
+      if (token.empty() || !is_piece_id_start(token[0]) || token.size() > 2)
+          return "";
+
+      std::string symbol(1, c == WHITE ? char(std::toupper(static_cast<unsigned char>(token[0])))
+                                      : char(std::tolower(static_cast<unsigned char>(token[0]))));
+      if (token.size() == 2) {
+          if (!is_piece_id_suffix(token[1]))
+              return "";
+          symbol.push_back(token[1]);
+      }
+      return symbol;
+  }
+
+  void rebuild_piece_symbol_maps() {
+      symbolToPiece.clear();
+      symbolToPieceType.clear();
+      for (Piece pc = W_PAWN; pc < PIECE_NB; ++pc)
+      {
+          if (pieceToSymbol[pc].empty() && pieceToChar[pc] != ' ')
+              pieceToSymbol[pc] = std::string(1, pieceToChar[pc]);
+          if (pieceToSymbolSynonyms[pc].empty() && pieceToCharSynonyms[pc] != ' ')
+              pieceToSymbolSynonyms[pc] = std::string(1, pieceToCharSynonyms[pc]);
+          if (!pieceToSymbol[pc].empty())
+          {
+              symbolToPiece[pieceToSymbol[pc]] = pc;
+              std::string typeSymbol = pieceToSymbol[pc];
+              typeSymbol[0] = char(std::toupper(static_cast<unsigned char>(typeSymbol[0])));
+              symbolToPieceType[typeSymbol] = type_of(pc);
+          }
+          if (!pieceToSymbolSynonyms[pc].empty())
+          {
+              symbolToPiece[pieceToSymbolSynonyms[pc]] = pc;
+              std::string typeSymbol = pieceToSymbolSynonyms[pc];
+              typeSymbol[0] = char(std::toupper(static_cast<unsigned char>(typeSymbol[0])));
+              symbolToPieceType[typeSymbol] = type_of(pc);
+          }
+      }
+  }
+
+  Piece piece_from_symbol(const std::string& token) const {
+      auto it = symbolToPiece.find(token);
+      return it == symbolToPiece.end() ? NO_PIECE : it->second;
+  }
+
+  PieceType piece_type_from_symbol(const std::string& token) const {
+      if (token.empty())
+          return NO_PIECE_TYPE;
+      std::string typeToken = token;
+      typeToken[0] = char(std::toupper(static_cast<unsigned char>(typeToken[0])));
+      auto it = symbolToPieceType.find(typeToken);
+      return it == symbolToPieceType.end() ? NO_PIECE_TYPE : it->second;
+  }
+
+  const std::string& piece_symbol(Piece pc) const {
+      static const std::string empty;
+      return pieceToSymbol[pc].empty() ? empty : pieceToSymbol[pc];
+  }
+
+  const std::string& piece_symbol_synonym(Piece pc) const {
+      static const std::string empty;
+      return pieceToSymbolSynonyms[pc].empty() ? empty : pieceToSymbolSynonyms[pc];
+  }
+
+  void add_piece(PieceType pt, const std::string& token, std::string betza = "", const std::string& token2 = "") {
+      std::string whiteSymbol = normalize_piece_symbol(token, WHITE);
+      std::string blackSymbol = normalize_piece_symbol(token, BLACK);
+      std::string whiteSyn = normalize_piece_symbol(token2, WHITE);
+      std::string blackSyn = normalize_piece_symbol(token2, BLACK);
+
+      if (whiteSymbol.empty() || blackSymbol.empty())
+      {
+          remove_piece(pt);
+          return;
+      }
+
+      auto remove_if_duplicate = [&](const std::string& symbol) {
+          if (symbol.empty())
+              return;
+          for (Piece p = W_PAWN; p < PIECE_NB; ++p)
+              if (pieceToSymbol[p] == symbol || pieceToSymbolSynonyms[p] == symbol)
+                  remove_piece(type_of(p));
+      };
+
+      remove_if_duplicate(whiteSymbol);
+      remove_if_duplicate(blackSymbol);
+      remove_if_duplicate(whiteSyn);
+      remove_if_duplicate(blackSyn);
+
+      pieceToChar[make_piece(WHITE, pt)] = whiteSymbol[0];
+      pieceToChar[make_piece(BLACK, pt)] = blackSymbol[0];
+      pieceToCharSynonyms[make_piece(WHITE, pt)] = whiteSyn.empty() ? ' ' : whiteSyn[0];
+      pieceToCharSynonyms[make_piece(BLACK, pt)] = blackSyn.empty() ? ' ' : blackSyn[0];
+      pieceToSymbol[make_piece(WHITE, pt)] = whiteSymbol;
+      pieceToSymbol[make_piece(BLACK, pt)] = blackSymbol;
+      pieceToSymbolSynonyms[make_piece(WHITE, pt)] = whiteSyn;
+      pieceToSymbolSynonyms[make_piece(BLACK, pt)] = blackSyn;
       pieceTypes |= pt;
-      // Add betza notation for custom piece
       if (is_custom(pt))
           customPiece[pt - CUSTOM_PIECES] = betza;
+  }
+
+  void add_piece(PieceType pt, char c, std::string betza = "", char c2 = ' ') {
+      std::string token(1, c);
+      std::string token2;
+      if (c2 != ' ')
+          token2 = std::string(1, c2);
+      add_piece(pt, token, betza, token2);
   }
 
   void add_piece(PieceType pt, char c, char c2) {
@@ -205,6 +312,10 @@ struct Variant {
       pieceToChar[make_piece(BLACK, pt)] = ' ';
       pieceToCharSynonyms[make_piece(WHITE, pt)] = ' ';
       pieceToCharSynonyms[make_piece(BLACK, pt)] = ' ';
+      pieceToSymbol[make_piece(WHITE, pt)].clear();
+      pieceToSymbol[make_piece(BLACK, pt)].clear();
+      pieceToSymbolSynonyms[make_piece(WHITE, pt)].clear();
+      pieceToSymbolSynonyms[make_piece(BLACK, pt)].clear();
       pieceTypes &= ~piece_set(pt);
       // erase from promotion types to ensure consistency
       promotionPieceTypes[WHITE] &= ~piece_set(pt);
@@ -214,6 +325,10 @@ struct Variant {
   void reset_pieces() {
       pieceToChar = std::string(PIECE_NB, ' ');
       pieceToCharSynonyms = std::string(PIECE_NB, ' ');
+      pieceToSymbol.assign(PIECE_NB, "");
+      pieceToSymbolSynonyms.assign(PIECE_NB, "");
+      symbolToPiece.clear();
+      symbolToPieceType.clear();
       pieceTypes = NO_PIECE_SET;
       // clear promotion types to ensure consistency
       promotionPieceTypes[WHITE] = NO_PIECE_SET;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -484,9 +484,27 @@ startFen = 8/pppppppp/8/8/8/8/PPPPPPPP/8 w - - 0 1
 promotionPieceTypes = q
 castling = false
 stalemateValue = loss
-flagPiece = q
-flagRegionWhite = *8
-flagRegionBlack = *1
+
+[xxl]
+maxRank = 14
+maxFile = n
+startFen = rnbhcmakmcebnr/pppppppppppppp/14/14/14/14/14/14/14/14/14/14/PPPPPPPPPPPPPP/RNBHCMAKMCEBNR w KQkq - 0 1
+rook = r
+knight = n
+bishop = b
+archbishop = h
+chancellor = e
+customPiece1 = c:C
+centaur = m
+amazon = a
+king = k
+queen = q
+pawn = p
+promotionPieceTypes = q
+promotionRegionWhite = *8
+promotionRegionBlack = *7
+castlingKingsideFile = m
+castlingQueensideFile = c
 
 #https://github.com/yagu0/vchess/blob/master/client/src/translations/rules/Pawnsking/en.pug
 [pawnsking:pawnsonly]

--- a/src/xboard.cpp
+++ b/src/xboard.cpp
@@ -418,14 +418,31 @@ void StateMachine::process_command(std::string token, std::istringstream& is) {
           && std::getline(is, token, '[') && std::getline(is, black_holdings, ']'))
       {
           std::string fen;
-          char color, pieceType;
+          char color;
+          bool used_single = false;
           // Use the obtained holding if available to avoid race conditions
-          if (is >> color && is >> pieceType)
+          if (is >> color)
           {
-              fen = pos.fen();
-              fen.insert(fen.find(']'), 1, toupper(color) == 'B' ? tolower(pieceType) : toupper(pieceType));
+              char base;
+              if (is >> base)
+              {
+                  std::string token_piece(1, base);
+                  if (Variant::is_piece_id_suffix(is.peek()))
+                  {
+                      char suffix;
+                      is >> suffix;
+                      token_piece.push_back(suffix);
+                  }
+                  std::string symbol = Variant::normalize_piece_symbol(token_piece, toupper(color) == 'B' ? BLACK : WHITE);
+                  if (!symbol.empty())
+                  {
+                      fen = pos.fen();
+                      fen.insert(fen.find(']'), symbol);
+                      used_single = true;
+                  }
+              }
           }
-          else
+          if (!used_single)
           {
               std::transform(black_holdings.begin(), black_holdings.end(), black_holdings.begin(), ::tolower);
               fen = pos.fen(false, false, 0, white_holdings + black_holdings);


### PR DESCRIPTION
  - Aligns data generation and tooling with VLB board sizes and move encoding so the NNUE pipeline stays consistent with the engine.
  - Switch PackedSFEN to VLB‑ready layouts (dynamic bit widths, fixed‑width piece encoding when board/piece counts exceed legacy limits).
  - Support VLB move packing with MOVE_SQUARE_BITS and 32‑bit moves where required.
  - Emit VLB‑aware trainer config fields (FILES/RANKS/SQUARES, MOVE_SQUARE_BITS, NNUE_KING, DATA_SIZE).
  - Preserve wall‑square and pocket packing rules with VLB‑compatible bit budgets.
  - Keep parser/gating logic aligned with engine changes for Seirawan and large boards.